### PR TITLE
[TSK-65] OpenAI API 연동 및 Clova와 교체 가능 구조, 프롬프트 서버 이전

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,17 @@ VITE_MESSAGING_SENDER_ID=...
 VITE_APP_ID=...
 VITE_MEASUREMENT_ID=...
 ```
+- **AI Provider** (선택): 미설정 시 OpenAI 사용. Clova 사용 시:
+```bash
+VITE_AI_PROVIDER=clova
+```
+
 #### functions/.env
+- **OpenAI 사용 시** (기본): Firebase Functions 설정에 `OPENAI_API_KEY` 추가
+```bash
+OPENAI_API_KEY=your_openai_api_key
+```
+- **Clova 사용 시**: `VITE_AI_PROVIDER=clova` 설정 후
 ```bash
 CLOVA_API_KEY=your_clova_api_key
 ```

--- a/app/src/api/ai-api.ts
+++ b/app/src/api/ai-api.ts
@@ -1,0 +1,19 @@
+import type { ChatCompletionResponse, ContentType } from '../types';
+import { chatCompletions as clovaChatCompletions } from './clova-api';
+import { chatCompletions as openaiChatCompletions } from './openai-api';
+
+const provider = import.meta.env.VITE_AI_PROVIDER ?? 'openai';
+
+/**
+ * 환경변수 VITE_AI_PROVIDER에 따라 Clova 또는 OpenAI를 호출합니다.
+ * 미설정 시 OpenAI 사용. "clova"이면 Clova 사용.
+ */
+export async function chatCompletions(
+  text: string,
+  contentType: ContentType = 'markdown'
+): Promise<ChatCompletionResponse> {
+  if (provider === 'clova') {
+    return clovaChatCompletions(text, contentType);
+  }
+  return openaiChatCompletions(text, contentType);
+}

--- a/app/src/api/openai-api.ts
+++ b/app/src/api/openai-api.ts
@@ -5,7 +5,8 @@ const FUNCTIONS_URL = import.meta.env.PROD
   : '/api';
 
 /**
- * CLOVA Studio - Firebase Functions를 통해 호출
+ * OpenAI - Firebase Functions openaiChatCompletions를 통해 호출 (프롬프트는 서버에서 처리)
+ * 요청/응답 형태는 clova-api와 동일 (백엔드에서 Clova 형식으로 정규화)
  */
 export async function chatCompletions(
   text: string,
@@ -16,7 +17,7 @@ export async function chatCompletions(
 
   let response: Response;
   try {
-    response = await fetch(`${FUNCTIONS_URL}/chatCompletions`, {
+    response = await fetch(`${FUNCTIONS_URL}/openaiChatCompletions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ contentType, text }),

--- a/app/src/hooks/useTodayFlashcards.ts
+++ b/app/src/hooks/useTodayFlashcards.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { User } from 'firebase/auth';
 import { store } from '../firebase';
-import { chatCompletions } from '../api/clova-api';
+import { chatCompletions } from '../api/ai-api';
 import { getCommits, getFilename, getMarkdown, type CommitDetail } from '../api/github-api';
 import { getCurrentDate } from '../modules/utils';
 import { useNavigationStore } from '../stores/navigationStore';

--- a/app/src/pages/LandingDemo.tsx
+++ b/app/src/pages/LandingDemo.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { FlashCardPlayer } from '../features/flashcard';
 import type { FlashCard } from '../features/flashcard';
-import { chatCompletions } from '../api/clova-api';
+import { chatCompletions } from '../api/ai-api';
 
 interface CommitData {
   sha: string;

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_MEASUREMENT_ID: string
   readonly VITE_USER_ID: string
   readonly VITE_SCHEDULE_CODE: string
+  readonly VITE_AI_PROVIDER?: 'clova' | 'openai'
 }
 
 interface ImportMeta {

--- a/functions/src/clova.ts
+++ b/functions/src/clova.ts
@@ -1,4 +1,5 @@
 import {onRequest} from "firebase-functions/v2/https";
+import {getFlashcardPrompt, type ContentType} from "./prompts.js";
 
 /**
  * CLOVA Studio Chat Completion API Response
@@ -43,12 +44,18 @@ export const chatCompletions = onRequest(
   },
   async (req, res) => {
     try {
-      const {prompt, text} = req.body;
+      const {contentType, text} = req.body;
 
-      if (!prompt || !text) {
-        res.status(400).json({error: "prompt and text are required"});
+      if (!text || !contentType) {
+        res.status(400).json({error: "contentType and text are required"});
         return;
       }
+      if (contentType !== "markdown" && contentType !== "code-diff") {
+        res.status(400).json({error: "contentType must be 'markdown' or 'code-diff'"});
+        return;
+      }
+
+      const prompt = getFlashcardPrompt(contentType as ContentType);
 
       // 고유한 요청 ID 생성
       const requestId = crypto.randomUUID().replace(/-/g, "");

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,3 +10,4 @@ initializeApp();
 export * from "./github.js";
 export * from "./schedule.js";
 export * from "./clova.js";
+export * from "./openai.js";

--- a/functions/src/openai.ts
+++ b/functions/src/openai.ts
@@ -1,0 +1,123 @@
+import {onRequest} from "firebase-functions/v2/https";
+import {getFlashcardPrompt, type ContentType} from "./prompts.js";
+
+/**
+ * Clova와 동일한 형태로 앱에서 사용하는 정규화 응답 타입
+ */
+interface NormalizedChatCompletionResponse {
+  status: {
+    code: string;
+    message: string;
+  };
+  result: {
+    message: {
+      role: string;
+      content: string;
+    };
+    finishReason: string;
+    created: number;
+    seed: number;
+    usage: {
+      promptTokens: number;
+      completionTokens: number;
+      totalTokens: number;
+    };
+  };
+}
+
+const OPENAI_MODEL = "gpt-4o-mini";
+
+/**
+ * OpenAI Chat Completions - 요청은 { contentType, text }, 프롬프트는 서버에서 조회
+ * 응답은 Clova와 동일한 형태로 정규화해 반환
+ */
+export const openaiChatCompletions = onRequest(
+  {
+    cors: true,
+    region: "asia-northeast3",
+    invoker: "public",
+  },
+  async (req, res) => {
+    try {
+      const apiKey = process.env.OPENAI_API_KEY;
+      if (!apiKey) {
+        res.status(500).json({error: "OpenAI API 호출 실패: OPENAI_API_KEY가 설정되지 않았습니다."});
+        return;
+      }
+
+      const {contentType, text} = req.body;
+
+      if (!text || !contentType) {
+        res.status(400).json({error: "contentType and text are required"});
+        return;
+      }
+      if (contentType !== "markdown" && contentType !== "code-diff") {
+        res.status(400).json({error: "contentType must be 'markdown' or 'code-diff'"});
+        return;
+      }
+
+      const prompt = getFlashcardPrompt(contentType as ContentType);
+
+      const response = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: OPENAI_MODEL,
+          messages: [
+            {role: "system", content: prompt},
+            {role: "user", content: text},
+          ],
+          temperature: 0.5,
+          max_tokens: 4096,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error("OpenAI API error:", response.status, errorText);
+        res.status(500).json({
+          error: `OpenAI API 호출 실패: ${response.status} - ${errorText}`,
+        });
+        return;
+      }
+
+      const data = await response.json() as {
+        choices?: Array<{
+          message?: { content?: string };
+          finish_reason?: string;
+        }>;
+        usage?: {
+          prompt_tokens?: number;
+          completion_tokens?: number;
+          total_tokens?: number;
+        };
+        created?: number;
+      };
+
+      const content = data.choices?.[0]?.message?.content ?? "";
+      const usage = data.usage ?? {};
+      const normalized: NormalizedChatCompletionResponse = {
+        status: {code: "200", message: "OK"},
+        result: {
+          message: {role: "assistant", content},
+          finishReason: data.choices?.[0]?.finish_reason ?? "stop",
+          created: data.created ?? Math.floor(Date.now() / 1000),
+          seed: 0,
+          usage: {
+            promptTokens: usage.prompt_tokens ?? 0,
+            completionTokens: usage.completion_tokens ?? 0,
+            totalTokens: usage.total_tokens ?? 0,
+          },
+        },
+      };
+
+      res.json(normalized);
+    } catch (error) {
+      console.error("Error calling OpenAI API:", error);
+      res.status(500).json({error: "OpenAI API 호출 실패"});
+    }
+  }
+);

--- a/functions/src/prompts.ts
+++ b/functions/src/prompts.ts
@@ -1,0 +1,14 @@
+/**
+ * 플래시카드용 AI 시스템 프롬프트 (Clova/OpenAI 공통)
+ * 클라이언트에 노출되지 않도록 서버에서만 사용
+ */
+export type ContentType = "markdown" | "code-diff";
+
+const OUTPUT_FORMAT =
+  "질문은 다음과 같은 형식으로 출력해주세요. [\"첫 번째 질문\", \"두 번째 질문\", ...]";
+
+export function getFlashcardPrompt(contentType: ContentType): string {
+  return contentType === "markdown"
+    ? `마크다운 파일을 읽고 질문을 만들어주세요. ${OUTPUT_FORMAT}`
+    : `코드 변경 내용(diff)을 보고 질문을 만들어주세요. 변경된 코드의 목적, 동작, 영향 등에 대해 물어보세요. ${OUTPUT_FORMAT}`;
+}


### PR DESCRIPTION
### Purpose

- 클로바(HyperCLOVA X) 대신 **OpenAI API**를 사용할 수 있도록 연동한다.
- 두 provider를 환경변수로 전환할 수 있게 하며, 클로바 코드는 유지한다.
- 플래시카드용 시스템 프롬프트를 서버(Firebase Functions)로 이전해 보안을 강화한다.

### Description

**1. OpenAI API 추가**
- `functions/src/openai.ts`: `openaiChatCompletions` HTTP 함수 추가. 요청 `contentType` + `text`로 프롬프트는 서버에서 조회, 응답은 Clova와 동일한 형태로 정규화.
- `app/src/api/openai-api.ts`: `POST /openaiChatCompletions` 호출 (body: `contentType`, `text`).
- `app/src/api/ai-api.ts`: `VITE_AI_PROVIDER`에 따라 Clova 또는 OpenAI 호출. 미설정 시 **OpenAI** 사용, 모델 **gpt-4o-mini**.

**2. 프롬프트 서버 이전 (보안)**
- `functions/src/prompts.ts`: 플래시카드용 시스템 프롬프트 `getFlashcardPrompt(contentType)` 정의. Clova/OpenAI 함수에서 공통 사용.
- 요청 스펙 변경: `{ prompt, text }` → `{ contentType, text }`. 프롬프트 문구는 클라이언트에 노출되지 않음.
- `functions/src/clova.ts`, `functions/src/openai.ts`: body에서 `contentType` 검증 후 `getFlashcardPrompt(contentType)`로 프롬프트 조회.
- `app/src/api/prompts.ts` 삭제. `clova-api.ts`, `openai-api.ts`는 `contentType`, `text`만 전송.

**3. 호출부**
- `useTodayFlashcards.ts`, `LandingDemo.tsx`: `clova-api` 대신 `ai-api`의 `chatCompletions` 사용 (기존과 동일 시그니처).

| 구분 | 파일 | 변경 요약 |
|------|------|-----------|
| Functions | `openai.ts` | 신규. OpenAI Chat Completions 호출 + 정규화 응답 |
| Functions | `prompts.ts` | 신규. `getFlashcardPrompt(contentType)` |
| Functions | `clova.ts` | body를 `contentType`/`text`로 변경, `prompts` 사용 |
| Functions | `index.ts` | `export * from "./openai.js"` 추가 |
| App | `openai-api.ts` | 신규. `/openaiChatCompletions` 호출 |
| App | `ai-api.ts` | 신규. provider 분기, 기본 openai |
| App | `clova-api.ts` | body를 `contentType`/`text`로 변경, prompts import 제거 |
| App | `prompts.ts` | 삭제 |
| App | `vite-env.d.ts` | `VITE_AI_PROVIDER` 타입 추가 |
| App | `useTodayFlashcards.ts`, `LandingDemo.tsx` | import를 `ai-api`로 변경 |
| Docs | `README.md` | OpenAI/Clova 환경변수 및 기본 provider 안내 |

### How to test

1. **Functions**: `functions` 디렉터리에서 `pnpm run build` 성공 여부 확인.
2. **OpenAI 사용 (기본)**  
   - `functions/.env`에 `OPENAI_API_KEY` 설정.  
   - 앱 실행 후 플래시카드 생성 또는 랜딩 데모에서 AI 질문 생성이 정상 동작하는지 확인.
3. **Clova로 전환**  
   - `app/.env`에 `VITE_AI_PROVIDER=clova` 설정.  
   - `functions/.env`에 `CLOVA_API_KEY` 설정 후, 동일 플로우가 Clova로 동작하는지 확인.
4. **에러 케이스**: `contentType` 없이 또는 잘못된 값으로 요청 시 400 응답이 오는지 확인 (선택).

### Review Requirement

- **프롬프트 보안**: 클라이언트에서 프롬프트 문구가 전혀 전달/노출되지 않고, `contentType`만 넘기며 서버에서만 `prompts.ts`를 사용하는지 확인해 주세요.
- **기본 provider**: 기본이 OpenAI(gpt-4o-mini)이고, Clova는 `VITE_AI_PROVIDER=clova` 시에만 사용되는지 로직 확인 부탁드립니다.
- **Clova 호환성**: Clova 함수도 `contentType`/`text` 요청과 정규화된 응답 형태를 그대로 쓰는지 한 번만 봐 주시면 됩니다.

### Additional Info

- 관련 Notion: [OpenAI API 연동](https://www.notion.so/chucoding/OpenAI-API-307fd64d44a080e988c0fe5789115f4b)
- Clova 관련 코드/파일은 삭제하지 않았으며, 환경변수만으로 provider 전환이 가능합니다.