### PR TITLE
[TSK-109] 플래시카드 프롬프트 통합 및 ContentType 제거

### DIFF
--- a/app/src/api/ai-api.ts
+++ b/app/src/api/ai-api.ts
@@ -1,4 +1,4 @@
-import type { ChatCompletionResponse, ContentType } from '../types';
+import type { ChatCompletionResponse } from '../types';
 import { chatCompletions as clovaChatCompletions } from './clova-api';
 import { chatCompletions as openaiChatCompletions } from './openai-api';
 
@@ -8,12 +8,9 @@ const provider = import.meta.env.VITE_AI_PROVIDER ?? 'openai';
  * 환경변수 VITE_AI_PROVIDER에 따라 Clova 또는 OpenAI를 호출합니다.
  * 미설정 시 OpenAI 사용. "clova"이면 Clova 사용.
  */
-export async function chatCompletions(
-  text: string,
-  contentType: ContentType = 'markdown'
-): Promise<ChatCompletionResponse> {
+export async function chatCompletions(text: string): Promise<ChatCompletionResponse> {
   if (provider === 'clova') {
-    return clovaChatCompletions(text, contentType);
+    return clovaChatCompletions(text);
   }
-  return openaiChatCompletions(text, contentType);
+  return openaiChatCompletions(text);
 }

--- a/app/src/api/clova-api.ts
+++ b/app/src/api/clova-api.ts
@@ -1,4 +1,4 @@
-import type { ChatCompletionResponse, ContentType } from '../types';
+import type { ChatCompletionResponse } from '../types';
 
 const FUNCTIONS_URL = import.meta.env.PROD
   ? import.meta.env.VITE_FUNCTIONS_URL_PROD
@@ -7,10 +7,7 @@ const FUNCTIONS_URL = import.meta.env.PROD
 /**
  * CLOVA Studio - Firebase Functions를 통해 호출
  */
-export async function chatCompletions(
-  text: string,
-  contentType: ContentType = 'markdown'
-): Promise<ChatCompletionResponse> {
+export async function chatCompletions(text: string): Promise<ChatCompletionResponse> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
@@ -19,7 +16,7 @@ export async function chatCompletions(
     response = await fetch(`${FUNCTIONS_URL}/chatCompletions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ contentType, text }),
+      body: JSON.stringify({ text }),
       signal: controller.signal,
     });
   } catch (err) {

--- a/app/src/api/openai-api.ts
+++ b/app/src/api/openai-api.ts
@@ -1,4 +1,4 @@
-import type { ChatCompletionResponse, ContentType } from '../types';
+import type { ChatCompletionResponse } from '../types';
 
 const FUNCTIONS_URL = import.meta.env.PROD
   ? import.meta.env.VITE_FUNCTIONS_URL_PROD
@@ -8,10 +8,7 @@ const FUNCTIONS_URL = import.meta.env.PROD
  * OpenAI - Firebase Functions openaiChatCompletions를 통해 호출 (프롬프트는 서버에서 처리)
  * 요청/응답 형태는 clova-api와 동일 (백엔드에서 Clova 형식으로 정규화)
  */
-export async function chatCompletions(
-  text: string,
-  contentType: ContentType = 'markdown'
-): Promise<ChatCompletionResponse> {
+export async function chatCompletions(text: string): Promise<ChatCompletionResponse> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
@@ -20,7 +17,7 @@ export async function chatCompletions(
     response = await fetch(`${FUNCTIONS_URL}/openaiChatCompletions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ contentType, text }),
+      body: JSON.stringify({ text }),
       signal: controller.signal,
     });
   } catch (err) {

--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Slider from 'react-slick';
-import MarkdownBlock from '../../templates/MarkdownBlock';
 import CodeDiffBlock from '../../templates/CodeDiffBlock';
 import type { FlashCard } from './types';
 
@@ -169,7 +168,6 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
             )}
           >
             {cards.map((card, i) => {
-              const contentType = card.contentType || 'markdown';
               const isFlipped = flipped && currentSlide === i;
 
               return (
@@ -179,11 +177,7 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                   onClick={flipCard}
                 >
                   {isFlipped ? (
-                    contentType === 'code-diff' ? (
-                      <CodeDiffBlock diffContent={card.answer} />
-                    ) : (
-                      <MarkdownBlock markdown={card.answer} />
-                    )
+                    <CodeDiffBlock diffContent={card.answer} />
                   ) : (
                     <p className="text-[1.6rem] font-semibold text-[#1D232B] leading-[1.7] p-4 break-words [word-break:keep-all] whitespace-pre-line text-center max-[768px]:text-[1.3rem] max-[768px]:p-[10px] max-[480px]:text-[1.15rem]">
                       {card.question}

--- a/app/src/features/flashcard/index.ts
+++ b/app/src/features/flashcard/index.ts
@@ -1,3 +1,3 @@
 export { default as FlashCardPlayer } from './FlashCardPlayer';
 export type { FlashCardPlayerProps } from './FlashCardPlayer';
-export type { FlashCard, ContentType } from './types';
+export type { FlashCard } from './types';

--- a/app/src/features/flashcard/types.ts
+++ b/app/src/features/flashcard/types.ts
@@ -1,9 +1,6 @@
-export type ContentType = 'markdown' | 'code-diff';
-
 export interface FlashCard {
   question: string;
   answer: string;
-  contentType?: ContentType;
   metadata?: {
     filename?: string;
     commitMessage?: string;

--- a/app/src/pages/LandingDemo.tsx
+++ b/app/src/pages/LandingDemo.tsx
@@ -77,7 +77,7 @@ const LandingDemo: React.FC = () => {
 
   /** AI로 질문 생성, 실패 시 템플릿 폴백 */
   const generateAIQuestion = async (answerContent: string): Promise<string[]> => {
-    const result = await chatCompletions(answerContent, 'code-diff');
+    const result = await chatCompletions(answerContent);
     return JSON.parse(result.result.message.content);
   };
 
@@ -151,10 +151,9 @@ const LandingDemo: React.FC = () => {
       );
 
       // 카드 조합
-      const generated: FlashCard[] = detailedCommits.map((commit, i) => ({
+      const generated: FlashCard[] = detailedCommits.map((_, i) => ({
         question: aiResults[i],
         answer: answerContents[i],
-        contentType: commit.files?.some((f) => f.patch) ? 'code-diff' as const : 'markdown' as const,
       }));
 
       setCards(generated);

--- a/app/src/templates/MarkdownBlock.tsx
+++ b/app/src/templates/MarkdownBlock.tsx
@@ -9,6 +9,13 @@ interface MarkdownBlockProps {
   markdown: string;
 }
 
+/**
+ * MarkdownBlock
+ * @deprecated - CodeDiffBlock 사용
+ * 
+ * @param markdown - markdown 내용
+ * @returns MarkdownBlock
+ */
 const MarkdownBlock: React.FC<MarkdownBlockProps> = ({ markdown }) => {
   return (
     <div className="markdown-body">

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -11,11 +11,6 @@ export interface Repository {
 }
 
 /**
- * Content Type
- */
-export type ContentType = 'markdown' | 'code-diff';
-
-/**
  * CLOVA Studio Chat Completion API Response
  */
 export interface ChatCompletionResponse {

--- a/functions/src/clova.ts
+++ b/functions/src/clova.ts
@@ -1,5 +1,5 @@
 import {onRequest} from "firebase-functions/v2/https";
-import {getFlashcardPrompt, type ContentType} from "./prompts.js";
+import {getFlashcardPrompt} from "./prompts.js";
 
 /**
  * CLOVA Studio Chat Completion API Response
@@ -44,18 +44,14 @@ export const chatCompletions = onRequest(
   },
   async (req, res) => {
     try {
-      const {contentType, text} = req.body;
+      const {text} = req.body;
 
-      if (!text || !contentType) {
-        res.status(400).json({error: "contentType and text are required"});
-        return;
-      }
-      if (contentType !== "markdown" && contentType !== "code-diff") {
-        res.status(400).json({error: "contentType must be 'markdown' or 'code-diff'"});
+      if (!text) {
+        res.status(400).json({error: "text is required"});
         return;
       }
 
-      const prompt = getFlashcardPrompt(contentType as ContentType);
+      const prompt = getFlashcardPrompt();
 
       // 고유한 요청 ID 생성
       const requestId = crypto.randomUUID().replace(/-/g, "");

--- a/functions/src/openai.ts
+++ b/functions/src/openai.ts
@@ -1,5 +1,5 @@
 import {onRequest} from "firebase-functions/v2/https";
-import {getFlashcardPrompt, type ContentType} from "./prompts.js";
+import {getFlashcardPrompt} from "./prompts.js";
 
 /**
  * Clova와 동일한 형태로 앱에서 사용하는 정규화 응답 타입
@@ -28,7 +28,7 @@ interface NormalizedChatCompletionResponse {
 const OPENAI_MODEL = "gpt-4o-mini";
 
 /**
- * OpenAI Chat Completions - 요청은 { contentType, text }, 프롬프트는 서버에서 조회
+ * OpenAI Chat Completions - 요청은 { text }, 프롬프트는 서버에서 조회
  * 응답은 Clova와 동일한 형태로 정규화해 반환
  */
 export const openaiChatCompletions = onRequest(
@@ -45,18 +45,14 @@ export const openaiChatCompletions = onRequest(
         return;
       }
 
-      const {contentType, text} = req.body;
+      const {text} = req.body;
 
-      if (!text || !contentType) {
-        res.status(400).json({error: "contentType and text are required"});
-        return;
-      }
-      if (contentType !== "markdown" && contentType !== "code-diff") {
-        res.status(400).json({error: "contentType must be 'markdown' or 'code-diff'"});
+      if (!text) {
+        res.status(400).json({error: "text is required"});
         return;
       }
 
-      const prompt = getFlashcardPrompt(contentType as ContentType);
+      const prompt = getFlashcardPrompt();
 
       const response = await fetch("https://api.openai.com/v1/chat/completions", {
         method: "POST",

--- a/functions/src/prompts.ts
+++ b/functions/src/prompts.ts
@@ -2,13 +2,9 @@
  * 플래시카드용 AI 시스템 프롬프트 (Clova/OpenAI 공통)
  * 클라이언트에 노출되지 않도록 서버에서만 사용
  */
-export type ContentType = "markdown" | "code-diff";
-
 const OUTPUT_FORMAT =
   "질문은 다음과 같은 형식으로 출력해주세요. [\"첫 번째 질문\", \"두 번째 질문\", ...]";
 
-export function getFlashcardPrompt(contentType: ContentType): string {
-  return contentType === "markdown"
-    ? `마크다운 파일을 읽고 질문을 만들어주세요. ${OUTPUT_FORMAT}`
-    : `코드 변경 내용(diff)을 보고 질문을 만들어주세요. 변경된 코드의 목적, 동작, 영향 등에 대해 물어보세요. ${OUTPUT_FORMAT}`;
+export function getFlashcardPrompt(): string {
+  return `주어진 내용(마크다운 문서 또는 코드 변경 diff)을 읽고 질문을 만들어주세요. 마크다운인 경우 내용에 대해, 코드 변경인 경우 변경된 코드의 목적, 동작, 영향 등에 대해 물어보세요. ${OUTPUT_FORMAT}`;
 }


### PR DESCRIPTION
### Purpose

플래시카드용 AI 프롬프트를 마크다운/코드-diff 구분 없이 **하나로 통합**하고, **ContentType** 타입 및 관련 필드·API를 제거합니다. 카드 뒷면은 항상 diff로만 표시하며, GitHub 데이터도 **코드 변경(diff)만** 사용하도록 변경합니다.

### Description

**1. Functions**
- **`functions/src/prompts.ts`**: `ContentType` 타입 삭제. `getFlashcardPrompt()`를 인자 없이 호출해 단일 통합 프롬프트만 반환하도록 변경. 마크다운/코드-diff 모두 포괄하는 문구로 통합.
- **`functions/src/clova.ts`**, **`functions/src/openai.ts`**: 요청 body에서 `contentType` 제거, `text`만 필수로 검증. `getFlashcardPrompt()` 인자 없이 호출.

**2. App – 타입**
- **`app/src/types.ts`**: `ContentType` 타입 정의 삭제.
- **`app/src/features/flashcard/types.ts`**: `ContentType` 타입 및 `FlashCard.contentType` 필드 제거.
- **`app/src/features/flashcard/index.ts`**: `ContentType` re-export 제거.

**3. App – API**
- **`app/src/api/ai-api.ts`**, **clova-api.ts**, **openai-api.ts**: `chatCompletions(text: string)` 시그니처만 사용, 요청 body는 `{ text }` 만 전송.

**4. App – 훅·페이지·UI**
- **`app/src/hooks/useTodayFlashcards.ts`**: `ContentType`·`FlashCardData.contentType`·`GithubData.contentType` 제거. `getGithubData`는 `{ content, metadata }` 만 반환. `chatCompletions(content)` 만 호출. **추가:** 마크다운 분기 제거, **diff만 사용** (`getMarkdown` import 제거, `formatCodeDiff`만 사용).
- **`app/src/pages/LandingDemo.tsx`**: 카드 객체에서 `contentType` 필드 제거.
- **`app/src/features/flashcard/FlashCardPlayer.tsx`**: `MarkdownBlock` import 제거. 카드 뒷면은 항상 `CodeDiffBlock`만 사용 (contentType 분기 제거).

**유지한 것**
- 기존 주석 중 코드와 일치하는 내용은 수정·삭제 없이 유지.
- Firestore 등에 이미 저장된 카드의 `contentType` 필드는 읽지 않을 뿐, 마이그레이션은 하지 않음.

### How to test

1. `functions`에서 `pnpm run build`로 빌드가 통과하는지 확인.
2. `app`에서 `pnpm run dev`로 앱 실행 후, 로그인하여 오늘 플래시카드가 생성·표시되는지 확인.
3. 플래시카드 뒷면(답 보기)이 **항상 diff 스타일(CodeDiffBlock)** 로만 렌더되는지 확인 (마크다운 렌더링 없음).
4. 데모/랜딩에서 카드 생성 시 `contentType` 없이도 정상 동작하는지 확인.
5. (선택) Clova 또는 OpenAI 중 설정한 Provider로 AI 질문 생성이 되는지, API 요청 body에 `text`만 넘어가는지 네트워크 탭 등으로 확인.

### Review Requirement

- **`getGithubData`**: 마크다운 분기를 제거하고 diff만 사용하는 로직이 의도대로인지 (해당 날짜 커밋 중 diff가 있는 첫 커밋만 사용).
- **통합 프롬프트 문구** (`functions/src/prompts.ts`): 마크다운·코드-diff 모두를 한 문단으로 설명하는 문구가 적절한지.
- **FlashCardPlayer**: `MarkdownBlock` 제거 후 다른 화면에서 `MarkdownBlock`을 쓰지 않는지(현재는 사용처 없음).

### Additional Info

- 작업 목록: TSK-109 (마크다운 전용 프롬프트 제거).
- 브랜치: `refactor/TSK-109`.
- 기존 데이터 호환: 저장된 카드에 `contentType` 필드가 있어도 앱에서는 읽지 않으므로 별도 마이그레이션 없음.