### PR TITLE
[TSK-66] 플래시카드 UX 개선: 스와이프·플립, 파일 보기, 마크다운/코드 렌더링

### DIFF
--- a/app/src/api/github-api.ts
+++ b/app/src/api/github-api.ts
@@ -18,6 +18,10 @@ export interface FileChange {
   deletions: number;
   changes: number;
   patch?: string;
+  /** GitHub commit file: raw content URL (해당 커밋 시점 파일 원문) */
+  raw_url?: string;
+  /** GitHub commit file: blob URL */
+  blob_url?: string;
 }
 
 export interface CommitDetail {
@@ -58,6 +62,16 @@ export async function getMarkdown(filename: string): Promise<string> {
   
   const data: MarkdownResponse = response.data;
   return data.content;
+}
+
+/**
+ * raw_url로 해당 커밋 시점 파일 원문 조회 (private repo 대응으로 백엔드 경유)
+ */
+export async function getFileContent(rawUrl: string): Promise<string> {
+  const response = await apiClient.get<MarkdownResponse>('/getFileContent', {
+    params: { raw_url: rawUrl }
+  });
+  return response.data.content;
 }
 
 export async function getRepositories(): Promise<Repository[]> {

--- a/app/src/features/flashcard/types.ts
+++ b/app/src/features/flashcard/types.ts
@@ -1,8 +1,13 @@
+import type { FileChange } from '../../api/github-api';
+
 export interface FlashCard {
   question: string;
   answer: string;
   metadata?: {
-    filename?: string;
     commitMessage?: string;
+    /** 새 스키마: 전체 파일 목록 (raw_url 등) */
+    files?: FileChange[];
+    /** 하위 호환: 파일 하나만 있을 때 */
+    filename?: string;
   };
 }

--- a/app/src/hooks/useTodayFlashcards.ts
+++ b/app/src/hooks/useTodayFlashcards.ts
@@ -3,7 +3,7 @@ import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { User } from 'firebase/auth';
 import { store } from '../firebase';
 import { chatCompletions } from '../api/ai-api';
-import { getCommits, getFilename, type CommitDetail } from '../api/github-api';
+import { getCommits, getFilename, type CommitDetail, type FileChange } from '../api/github-api';
 import { getCurrentDate } from '../modules/utils';
 import { useNavigationStore } from '../stores/navigationStore';
 
@@ -13,8 +13,8 @@ export interface FlashCardData {
   question: string;
   answer: string;
   metadata?: {
-    filename?: string;
     commitMessage?: string;
+    files?: FileChange[];
   };
 }
 
@@ -115,8 +115,8 @@ async function generateFlashcards(): Promise<FlashCardData[]> {
 interface GithubData {
   content: string;
   metadata?: {
-    filename?: string;
     commitMessage?: string;
+    files?: FileChange[];
   };
 }
 
@@ -144,13 +144,14 @@ async function getGithubData(daysAgo: number): Promise<GithubData | null> {
   }
 
   for (const commit of commits) {
-    const commit_detail = await getFilename(commit.sha);
-    const codeDiff = formatCodeDiff(commit_detail);
+    const commitDetail = await getFilename(commit.sha);
+    const codeDiff = formatCodeDiff(commitDetail);
     if (codeDiff) {
       return {
         content: codeDiff,
         metadata: {
-          commitMessage: commit_detail.commit.message
+          commitMessage: commitDetail.commit.message,
+          files: commitDetail.files
         }
       };
     }

--- a/app/src/templates/CodeDiffBlock.tsx
+++ b/app/src/templates/CodeDiffBlock.tsx
@@ -42,7 +42,7 @@ const CodeDiffBlock: React.FC<CodeDiffBlockProps> = ({ diffContent }) => {
                       lineProps={(lineNumber) => {
                         const lineContent = String(children).split('\n')[lineNumber - 1] || '';
                         const style: React.CSSProperties = { display: 'block' };
-                        
+                        // AI 하이라이팅: 추가/삭제/헤더 라인 구분 (대비 4.5:1 이상 유지)
                         if (lineContent.startsWith('+') && !lineContent.startsWith('+++')) {
                           style.backgroundColor = 'rgba(46, 160, 67, 0.15)';
                           style.borderLeft = '3px solid #2ea043';
@@ -50,10 +50,9 @@ const CodeDiffBlock: React.FC<CodeDiffBlockProps> = ({ diffContent }) => {
                           style.backgroundColor = 'rgba(248, 81, 73, 0.15)';
                           style.borderLeft = '3px solid #f85149';
                         } else if (lineContent.startsWith('@@')) {
-                          style.backgroundColor = 'rgba(84, 174, 255, 0.15)';
+                          style.backgroundColor = 'rgba(84, 174, 255, 0.12)';
                           style.fontWeight = '600';
                         }
-                        
                         return { style };
                       }}
                       {...props}

--- a/app/src/templates/FileContentBlock.tsx
+++ b/app/src/templates/FileContentBlock.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { github } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import 'github-markdown-css/github-markdown.css';
+
+const EXT_TO_LANG: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  jsx: 'jsx',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  py: 'python',
+  json: 'json',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  md: 'markdown',
+  markdown: 'markdown',
+  yaml: 'yaml',
+  yml: 'yaml',
+  sh: 'bash',
+  bash: 'bash',
+  sql: 'sql',
+  go: 'go',
+  rs: 'rust',
+  rb: 'ruby',
+  java: 'java',
+  kt: 'kotlin',
+  swift: 'swift',
+};
+
+function getLanguageFromFilename(filename: string): string {
+  const ext = filename.replace(/^.*\./, '').toLowerCase();
+  return EXT_TO_LANG[ext] ?? ext;
+}
+
+function isMarkdownFile(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return lower.endsWith('.md') || lower.endsWith('.markdown');
+}
+
+interface FileContentBlockProps {
+  content: string;
+  filename?: string;
+}
+
+/**
+ * 파일 원문을 마크다운 또는 코드 하이라이트로 렌더링
+ * .md/.markdown → ReactMarkdown, 그 외 확장자 → SyntaxHighlighter
+ */
+const FileContentBlock: React.FC<FileContentBlockProps> = ({ content, filename = '' }) => {
+  if (isMarkdownFile(filename)) {
+    return (
+      <div className="markdown-body w-full h-full overflow-y-auto p-6 box-border text-left bg-white">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            code({ node, inline, className, children, ...props }: any) {
+              const match = /language-(\w+)/.exec(className || '');
+              if (!inline && match) {
+                return (
+                  <SyntaxHighlighter
+                    style={github}
+                    language={match[1]}
+                    PreTag="div"
+                    customStyle={{ margin: '0.5em 0', borderRadius: '6px', fontSize: '13px' }}
+                    codeTagProps={{
+                      style: {
+                        fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+                      },
+                    }}
+                    {...props}
+                  >
+                    {String(children).replace(/\n$/, '')}
+                  </SyntaxHighlighter>
+                );
+              }
+              return (
+                <code className={className} {...props}>
+                  {children}
+                </code>
+              );
+            },
+          }}
+        >
+          {content}
+        </ReactMarkdown>
+      </div>
+    );
+  }
+
+  const language = getLanguageFromFilename(filename) || 'text';
+  return (
+    <div className="w-full h-full overflow-auto p-4 bg-[#f6f8fa] rounded-b-3xl border border-[#d0d7de] border-t-0 box-border">
+      <SyntaxHighlighter
+        style={github}
+        language={language}
+        PreTag="div"
+        customStyle={{
+          margin: 0,
+          padding: 0,
+          background: 'transparent',
+          fontSize: '13px',
+          lineHeight: '1.45',
+        }}
+        codeTagProps={{
+          style: {
+            fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+          },
+        }}
+        showLineNumbers={content.split('\n').length > 5}
+      >
+        {content}
+      </SyntaxHighlighter>
+    </div>
+  );
+};
+
+export default FileContentBlock;


### PR DESCRIPTION
### Purpose

플래시카드 화면을 드래그/스와이프·플립 중심으로 바꾸고, 하단 컨트롤을 제거해 카드를 크게 보이게 하며, 뒷면에 Diff 보기/파일 보기 토글과 파일 원문 마크다운·코드 렌더링을 추가합니다.

### Description

- **레이아웃**
  - 하단 버튼(이전/뒤집기/다음) 제거, 카드 영역 확대(`min-h-[50vh] max-h-[80vh]`), 슬라이더에 `flex-1 min-h-0` 적용.
  - N/M 인디케이터는 상단 뱃지로 유지.
- **스와이프·플립**
  - `react-slick` `swipe={true}`로 터치/드래그로 카드 넘기기.
  - 카드 클릭 또는 Space/Enter로 플립, 키보드 단축키 유지(좌/우 이동, Space/상하 플립).
- **뒷면 헤더**
  - 뒤집힐 때만 표시. **Diff 보기**: 기존 `CodeDiffBlock`. **파일 보기**: 커밋 파일 원문을 `raw_url` 또는 `filename`으로 조회.
  - 여러 파일일 때 `<select>`로 선택, 한 개일 때 파일명만 표시.
- **메타데이터**
  - `metadata.files`: GitHub Commit API 응답의 `files` 배열 그대로 저장(`filename`, `raw_url`, `blob_url` 등).
  - 하위 호환: `metadata.filename`만 있어도 파일 보기 활성화, `getMarkdown(filename)`으로 조회.
- **파일 원문 조회**
  - `raw_url` 있음 → `getFileContent(raw_url)` (백엔드 신규 엔드포인트).
  - 없음/레거시 → `getMarkdown(filename)`.
- **파일 원문 렌더링**
  - `FileContentBlock` 신규: `.md`/`.markdown` → ReactMarkdown, 그 외 → SyntaxHighlighter(확장자별 언어).
- **AI 하이라이팅·접근성**
  - CodeDiffBlock diff 라인 강조 유지. `prefers-reduced-motion` 시 애니메이션 축소.
  - 카드 `role="button"`, `tabIndex={0}`, `aria-label`, `focus-visible`, 트랜지션 300ms.

**변경 파일 요약**

| 구분 | 파일 | 변경 내용 |
|------|------|-----------|
| 앱 | `app/src/features/flashcard/FlashCardPlayer.tsx` | 하단 컨트롤 제거, 카드 확대, 스와이프, 뒷면 헤더(토글), 파일 보기(선택·getFileContent/getMarkdown), FileContentBlock, 접근성 |
| 앱 | `app/src/features/flashcard/types.ts` | `metadata.files`, `metadata.filename`(하위호환) |
| 앱 | `app/src/templates/FileContentBlock.tsx` | **신규** 파일 원문 마크다운/코드 렌더링 |
| 앱 | `app/src/api/github-api.ts` | `FileChange`에 `raw_url`/`blob_url`, `getFileContent(rawUrl)` 추가 |
| 앱 | `app/src/hooks/useTodayFlashcards.ts` | `metadata.files = commitDetail.files`, AI에는 `formatCodeDiff(commitDetail)` 그대로 전달 |
| 백엔드 | `functions/src/github.ts` | `getFileContent(raw_url)` 엔드포인트 추가, 허용 host에 `github.com` 포함 |

### How to test

1. 앱 실행 후 플래시카드 페이지로 이동(오늘 플래시카드가 있는 계정으로 로그인).
2. **레이아웃**: 하단에 이전/뒤집기/다음 버튼이 없고, 카드가 화면을 크게 쓰는지 확인.
3. **스와이프**: 터치 또는 마우스 드래그로 카드가 넘어가는지, 좌/우 방향이 맞는지 확인.
4. **플립**: 카드 클릭 또는 Space/Enter로 앞·뒤 전환이 되는지 확인.
5. **Diff 보기**: 카드 뒤집기 → 헤더에서 "Diff 보기" 선택 시 기존 diff 마크다운이 보이는지 확인.
6. **파일 보기**: "파일 보기" 선택 시 파일 목록(또는 단일 파일명)이 보이고, 선택한 파일 원문이 마크다운/코드로 렌더되는지 확인. (Functions 배포 후 `getFileContent` 동작 확인.)
7. **접근성**: 카드에 탭 포커스 후 Space/Enter로 플립, 포커스 링이 보이는지 확인.

### Review Requirement

- **FlashCardPlayer**: 뒷면 헤더 토글·파일 선택 시 `effectiveFiles`/`hasFileView`/`currentRawUrl` 분기, fetch effect 의존성 배열이 의도대로인지.
- **getFileContent (functions)**: `raw_url` host 검증(`github.com`, `raw.githubusercontent.com`, `api.github.com`)과 Authorization 헤더로 fetch하는 부분.
- **하위 호환**: `metadata.files` 없이 `metadata.filename`만 있는 카드에서 파일 보기가 활성화되고 `getMarkdown`으로 한 개 파일이 보이는지.

### Additional Info

- Notion 정리: [플래시카드 UX 개선](https://www.notion.so/chucoding/UX-292fd64d44a08071ae48fe7028f654a0).
- `getFileContent` 사용을 위해 Firebase Functions 배포 필요: `firebase deploy --only functions:getFileContent` (또는 functions 전체 배포).
- GitHub API commit 응답의 `raw_url` 형식: `https://github.com/owner/repo/raw/{sha}/{filename}` (host `github.com` 허용 처리 완료).