### PR TITLE
[TSK-69] 매일 8시 PUSH 알림 발송 및 설정 토글

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -6,6 +6,9 @@ VITE_STORAGE_BUCKET=your_project.appspot.com
 VITE_MESSAGING_SENDER_ID=your_sender_id
 VITE_APP_ID=your_app_id
 VITE_MEASUREMENT_ID=your_measurement_id
+# FCM 웹 푸시용 VAPID 공개 키
+# Firebase 콘솔 → 프로젝트 선택 → 톱니바퀴 [프로젝트 설정] → Cloud Messaging 탭 → Web configuration → Web Push certificates → "키 쌍 생성" 후 나오는 공개 키
+# VITE_VAPID_KEY=
 
 # Firebase Functions (pnpm proxy 실행시 자동 생성)
 VITE_FIREBASE_PROJECT_ID=
@@ -13,6 +16,5 @@ VITE_FIREBASE_REGION=
 VITE_FUNCTIONS_URL_LOCAL=
 VITE_FUNCTIONS_URL_PROD=
 
-# 사용자 설정
-VITE_USER_ID=your_user_id_here
-VITE_SCHEDULE_CODE=your_schedule_code_here
+# 앱 설정
+VITE_AI_PROVIDER=openai

--- a/app/src/firebase.ts
+++ b/app/src/firebase.ts
@@ -13,7 +13,7 @@ const firebaseConfig = {
 };
 
 // Firebase 앱 초기화 (이미 초기화된 경우 기존 앱 사용)
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
+export const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
 
 // Auth 인스턴스 생성
 export const auth = getAuth(app);


### PR DESCRIPTION
### Purpose

매일 오전 8시(KST)에 복습 리마인더 푸시를 발송하고, 설정 화면에서 PUSH 알림을 켜거나 끌 수 있는 토글을 추가합니다. 발송 대상은 Firestore에 `pushEnabled`와 `fcmToken`을 가진 사용자로 제한합니다.

### Description

- **백엔드 (Cloud Functions)**
  - `functions/src/schedule.ts`: 기존 topic 발송 제거 → Firestore `users`에서 `pushEnabled === true`이고 `fcmToken`이 있는 사용자만 조회 후, 토큰 단위로 FCM 발송. 500개 단위 배치로 `sendEach` 호출.
  - 알림 메시지: title "오늘의 리마인더", body "복습할 카드가 도착했어요!", data `type`/`url` 유지.

- **프론트엔드 (앱)**
  - `app/src/firebase.ts`: `app` export 추가 (설정에서 FCM `getMessaging(app)` 동적 import용).
  - `app/src/pages/Settings.tsx`:
    - Firestore `users` 문서에서 `pushEnabled` 로드/저장 반영.
    - "알림" 섹션 추가: GitHub 리포지토리 블록 바로 아래, 제목 + 설명("매일 오전 8시에 복습 리마인더를 보내드려요") + PUSH 알림 라벨 + 스위치 토글.
    - 토글 ON: 알림 권한 요청 → FCM `getToken()` → `users/{uid}`에 `pushEnabled: true`, `fcmToken` 저장.
    - 토글 OFF: `updateDoc`으로 `pushEnabled: false`만 저장.
    - 토글 UI: OFF일 때 트랙이 카드 배경과 구분되도록 `bg-bg` + `border-border-medium` 적용, 썸 그림자로 가독성 보강.

- **기타**
  - `app/.env.example`: FCM 웹 푸시용 VAPID 키 안내 추가 (프로젝트 설정 → Cloud Messaging → Web Push certificates 경로 명시, 캠페인 메뉴와 구분).

| 수정/추가 파일 | 요약 |
|----------------|------|
| `functions/src/schedule.ts` | topic 제거, users 조회 후 토큰 단위 발송 |
| `app/src/firebase.ts` | `app` export |
| `app/src/pages/Settings.tsx` | pushEnabled/fcmToken 로드·저장, 알림 섹션·토글·handlePushToggle, 토글 OFF 시 대비 개선 |
| `app/.env.example` | VAPID 키 주석 가이드 |

### How to test

1. **설정 페이지**
   - 로그인 후 설정 진입 → "알림" 섹션에 "PUSH 알림" 토글이 보이는지 확인.
   - 토글 OFF일 때: 트랙이 카드 배경과 구분되어 보이는지(어두운 트랙 + 테두리) 확인.
   - 토글 ON: 브라우저 알림 권한 허용 후, Firestore `users/{uid}`에 `pushEnabled: true`, `fcmToken`이 저장되는지 확인.
   - 토글 OFF: `pushEnabled: false`로만 업데이트되는지 확인.

2. **스케줄 함수 (배포 후)**
   - Firebase Console → Functions 로그에서 `sendDaily8amPush` 실행 시, `pushEnabled` + `fcmToken` 있는 사용자에게만 발송되는지 확인 (또는 에뮬레이터로 스케줄 트리거 후 로그 확인).

3. **선택**
   - `.env`에 `VITE_VAPID_KEY` 없이도 토글이 동작하는지(기본 VAPID 사용 여부) 확인.

### Review Requirement

- FCM 토큰을 Firestore에 저장할 때 기존 `users` 문서 필드(repositoryFullName, githubToken 등)를 덮어쓰지 않고 `setDoc` 시 `...existingData`로 병합하는지 확인해 주세요.
- 설정 저장(리포지토리 저장) 시 `pushEnabled`/`fcmToken`이 유지되는지 한 번 더 봐 주시면 좋습니다.
- 스케줄 함수에서 토큰 500개 초과 시 배치 분할 로직이 의도대로 동작하는지 확인 부탁드립니다.

### Additional Info

- Notion 문서 정리: [firebase scheduler](https://www.notion.so/chucoding/firebase-scheduler-283fd64d44a080aca43ee4fc72f4c9db) 페이지에 "Firebase PUSH 알림 구현 정리" 섹션 추가됨.
- VAPID 키는 **프로젝트 설정 → Cloud Messaging → Web Push certificates**에서만 확인 가능하며, Engage(캠페인) 메뉴에는 없습니다.