### PR TITLE
[TSK-73] Firebase GA4 및 랜딩 이벤트·Clarity 연동

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -18,3 +18,6 @@ VITE_FUNCTIONS_URL_PROD=
 
 # 앱 설정
 VITE_AI_PROVIDER=openai
+
+# Microsoft Clarity (히트맵·세션 녹화, 선택). https://clarity.microsoft.com/ 에서 프로젝트 생성 후 ID 입력
+# VITE_CLARITY_PROJECT_ID=

--- a/app/index.html
+++ b/app/index.html
@@ -78,9 +78,9 @@
 
         <!-- Desktop: 로고 + Get Started만 (Google/ChatGPT 스타일) -->
         <div class="hidden md:flex items-center gap-6">
-          <a href="#how-it-works" class="text-[0.9rem] text-text-body no-underline font-medium transition-colors duration-200 hover:text-primary">How it Works</a>
-          <a href="#features" class="text-[0.9rem] text-text-body no-underline font-medium transition-colors duration-200 hover:text-primary">Features</a>
-          <a href="/app" class="py-2.5 px-5 bg-primary text-bg rounded-lg text-[0.9rem] font-semibold no-underline transition-all duration-200 hover:bg-primary-dark hover:-translate-y-px hover:shadow-[0_6px_20px_rgba(7,166,107,0.3)]">
+          <a href="#how-it-works" data-landing-action="nav_how_it_works" class="text-[0.9rem] text-text-body no-underline font-medium transition-colors duration-200 hover:text-primary">How it Works</a>
+          <a href="#features" data-landing-action="nav_features" class="text-[0.9rem] text-text-body no-underline font-medium transition-colors duration-200 hover:text-primary">Features</a>
+          <a href="/app" data-landing-action="get_started_nav" class="py-2.5 px-5 bg-primary text-bg rounded-lg text-[0.9rem] font-semibold no-underline transition-all duration-200 hover:bg-primary-dark hover:-translate-y-px hover:shadow-[0_6px_20px_rgba(7,166,107,0.3)]">
             Get Started
           </a>
         </div>
@@ -94,9 +94,9 @@
       </div>
 
       <div class="hidden peer-checked:flex flex-col gap-1 px-6 pb-4 rounded-b-xl bg-surface/95 backdrop-blur-xl md:!hidden animate-fade-in">
-        <a href="#how-it-works" class="py-2.5 text-[0.95rem] text-text-body no-underline font-medium">How it Works</a>
-        <a href="#features" class="py-2.5 text-[0.95rem] text-text-body no-underline font-medium">Features</a>
-        <a href="/app" class="mt-1 flex items-center justify-center gap-2 py-2.5 bg-primary text-bg rounded-lg text-[0.9rem] font-semibold no-underline">
+        <a href="#how-it-works" data-landing-action="nav_how_it_works_mobile" class="py-2.5 text-[0.95rem] text-text-body no-underline font-medium">How it Works</a>
+        <a href="#features" data-landing-action="nav_features_mobile" class="py-2.5 text-[0.95rem] text-text-body no-underline font-medium">Features</a>
+        <a href="/app" data-landing-action="get_started_nav_mobile" class="mt-1 flex items-center justify-center gap-2 py-2.5 bg-primary text-bg rounded-lg text-[0.9rem] font-semibold no-underline">
           Get Started
         </a>
       </div>
@@ -228,10 +228,10 @@
           오늘의 커밋이 내일의 실력이 됩니다.
         </p>
         <div class="flex flex-wrap items-center justify-center gap-3 max-[480px]:flex-col">
-          <a href="/app" class="inline-flex items-center gap-3 py-4 px-10 bg-primary text-bg rounded-xl text-lg font-bold no-underline transition-all duration-300 shadow-[0_8px_30px_rgba(7,166,107,0.25)] hover:bg-primary-dark hover:-translate-y-0.5 hover:shadow-[0_12px_40px_rgba(7,166,107,0.35)] max-[480px]:w-full max-[480px]:justify-center cursor-pointer">
+          <a href="/app" data-landing-action="get_started_footer" class="inline-flex items-center gap-3 py-4 px-10 bg-primary text-bg rounded-xl text-lg font-bold no-underline transition-all duration-300 shadow-[0_8px_30px_rgba(7,166,107,0.25)] hover:bg-primary-dark hover:-translate-y-0.5 hover:shadow-[0_12px_40px_rgba(7,166,107,0.35)] max-[480px]:w-full max-[480px]:justify-center cursor-pointer">
             Get Started with GitHub
           </a>
-          <button type="button" id="pwa-install-btn" class="pwa-install-btn hidden inline-flex items-center gap-2.5 py-4 px-8 bg-transparent text-text-body border border-border rounded-xl text-base font-semibold transition-all duration-300 hover:bg-surface hover:border-border-medium hover:text-text max-[480px]:w-full max-[480px]:justify-center cursor-pointer" aria-label="앱 설치">
+          <button type="button" id="pwa-install-btn" data-landing-action="pwa_install" class="pwa-install-btn hidden inline-flex items-center gap-2.5 py-4 px-8 bg-transparent text-text-body border border-border rounded-xl text-base font-semibold transition-all duration-300 hover:bg-surface hover:border-border-medium hover:text-text max-[480px]:w-full max-[480px]:justify-center cursor-pointer" aria-label="앱 설치">
             <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
             앱으로 설치
           </button>
@@ -244,9 +244,9 @@
       <div class="max-w-6xl mx-auto flex items-center justify-between flex-wrap gap-4 max-[768px]:flex-col max-[768px]:items-center max-[768px]:text-center max-[768px]:gap-3">
         <a href="/" class="no-underline flex items-center" aria-label="CodeRecall 홈"><img src="/logo.png" alt="CodeRecall" class="h-8 opacity-90 max-[480px]:h-6" /></a>
         <div class="flex items-center gap-6 text-text-muted text-sm max-[480px]:gap-4">
-          <a href="https://github.com/chucoding" target="_blank" rel="noopener noreferrer" class="transition-colors duration-200 hover:text-text-light no-underline text-text-muted">GitHub</a>
-          <a href="/terms" class="transition-colors duration-200 hover:text-text-light no-underline text-text-muted">Terms</a>
-          <a href="/privacy" class="transition-colors duration-200 hover:text-text-light no-underline text-text-muted">Privacy</a>
+          <a href="https://github.com/chucoding" data-landing-action="footer_github" target="_blank" rel="noopener noreferrer" class="transition-colors duration-200 hover:text-text-light no-underline text-text-muted">GitHub</a>
+          <a href="/terms" data-landing-action="footer_terms" class="transition-colors duration-200 hover:text-text-light no-underline text-text-muted">Terms</a>
+          <a href="/privacy" data-landing-action="footer_privacy" class="transition-colors duration-200 hover:text-text-light no-underline text-text-muted">Privacy</a>
         </div>
         <p class="text-text-muted/50 text-sm">&copy; 2026 CodeRecall</p>
       </div>

--- a/app/src/analytics.ts
+++ b/app/src/analytics.ts
@@ -1,0 +1,25 @@
+import { logEvent } from 'firebase/analytics';
+import { analytics } from './firebase';
+
+/**
+ * GA4 화면 추적 (퍼널 탐색에서 단계로 사용 가능)
+ */
+export function trackScreen(screenName: string, screenClass?: string): void {
+  if (!analytics) return;
+  // GA4 권장 이벤트 screen_view; Firebase 타입 정의가 엄격해 단언 사용
+  logEvent(analytics, 'screen_view' as Parameters<typeof logEvent>[1], {
+    screen_name: screenName,
+    ...(screenClass && { screen_class: screenClass }),
+  });
+}
+
+/**
+ * GA4 커스텀 이벤트 (퍼널·전환 분석용)
+ */
+export function trackEvent(
+  name: string,
+  params?: Record<string, string | number | boolean>
+): void {
+  if (!analytics) return;
+  logEvent(analytics, name, params);
+}

--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -4,6 +4,7 @@ import CodeDiffBlock from '../../templates/CodeDiffBlock';
 import FileContentBlock from '../../templates/FileContentBlock';
 import { getFileContent, getMarkdown } from '../../api/github-api';
 import type { FlashCard } from './types';
+import { trackEvent } from '../../analytics';
 
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -68,7 +69,15 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
   };
 
   const flipCard = () => {
-    setFlipped((prev) => !prev);
+    setFlipped((prev) => {
+      if (!prev) {
+        trackEvent('flashcard_flip', {
+          card_index: currentSlide + 1,
+          total_cards: cards.length,
+        });
+      }
+      return !prev;
+    });
   };
 
   useEffect(() => {

--- a/app/src/firebase.ts
+++ b/app/src/firebase.ts
@@ -1,4 +1,5 @@
 import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getAnalytics, type Analytics } from 'firebase/analytics';
 import { getAuth, GithubAuthProvider } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
@@ -14,6 +15,12 @@ const firebaseConfig = {
 
 // Firebase 앱 초기화 (이미 초기화된 경우 기존 앱 사용)
 export const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
+
+// Analytics 인스턴스 (measurementId가 있을 때만 초기화, SSR/미설정 환경 대비)
+export const analytics: Analytics | null =
+  typeof window !== 'undefined' && firebaseConfig.measurementId
+    ? getAnalytics(app)
+    : null;
 
 // Auth 인스턴스 생성
 export const auth = getAuth(app);

--- a/app/src/landing-main.tsx
+++ b/app/src/landing-main.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import LandingDemo from './pages/LandingDemo';
+import { trackEvent, trackScreen } from './analytics';
 
 const demoRoot = document.getElementById('demo-root');
 
@@ -9,6 +10,83 @@ if (demoRoot) {
   ReactDOM.createRoot(demoRoot).render(
     <React.StrictMode>
       <LandingDemo />
+    </React.StrictMode>
+  );
+}
+
+/**
+ * 랜딩 페이지 전용 GA 이벤트: 화면 뷰, 스크롤 깊이, 클릭(이탈/로그인 유도) 추적
+ */
+function useLandingAnalytics() {
+  // 랜딩 진입 시 screen_view 1회
+  useEffect(() => {
+    trackScreen('landing', 'LandingPage');
+  }, []);
+
+  // 스크롤 깊이: 25%, 50%, 75%, 100% 도달 시 각 1회
+  useEffect(() => {
+    const reached = new Set<number>();
+    const thresholds = [25, 50, 75, 100];
+
+    const onScroll = () => {
+      const max = document.documentElement.scrollHeight - window.innerHeight;
+      if (max <= 0) return;
+      const pct = Math.round((window.scrollY / max) * 100);
+      thresholds.forEach((t) => {
+        if (pct >= t && !reached.has(t)) {
+          reached.add(t);
+          trackEvent('landing_scroll', { depth: t });
+        }
+      });
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // 클릭 위임: data-landing-action 또는 href 기반으로 landing_click 전송
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const link = target.closest('a');
+      const button = target.closest('button');
+      const el = link ?? button;
+      if (!el) return;
+
+      const action =
+        el.getAttribute('data-landing-action') ||
+        (link?.getAttribute('href') === '/app' ? 'get_started' : null) ||
+        (link?.getAttribute('href')?.startsWith('#') ? 'nav_section' : null);
+      const destination = link?.getAttribute('href') ?? (button ? 'button' : '');
+
+      if (action) {
+        trackEvent('landing_click', {
+          action: action,
+          destination: String(destination).slice(0, 100),
+        });
+      }
+    };
+
+    document.addEventListener('click', onClick, true);
+    return () => document.removeEventListener('click', onClick, true);
+  }, []);
+}
+
+// 랜딩 진입점에서 훅 실행을 위해 래퍼 컴포넌트 사용
+function LandingWithAnalytics() {
+  useLandingAnalytics();
+  return null;
+}
+
+// analytics 훅은 React 트리 안에서 실행되어야 하므로 루트에 주입
+if (demoRoot) {
+  const analyticsRoot = document.createElement('div');
+  analyticsRoot.id = 'landing-analytics-root';
+  document.body.appendChild(analyticsRoot);
+  ReactDOM.createRoot(analyticsRoot).render(
+    <React.StrictMode>
+      <LandingWithAnalytics />
     </React.StrictMode>
   );
 }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -3,6 +3,15 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 
+// Microsoft Clarity (히트맵·세션 녹화): 프로젝트 ID가 있을 때만 로드
+const clarityId = import.meta.env.VITE_CLARITY_PROJECT_ID;
+if (typeof clarityId === 'string' && clarityId.trim()) {
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = 'https://www.clarity.ms/tag/' + clarityId.trim();
+  document.head.appendChild(script);
+}
+
 // PWA Service Worker 등록
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {

--- a/app/src/pages/LandingDemo.tsx
+++ b/app/src/pages/LandingDemo.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import { FlashCardPlayer } from '../features/flashcard';
 import type { FlashCard } from '../features/flashcard';
 import { generateDemoFlashcards } from '../lib/demoFlashcards';
+import { trackEvent } from '../analytics';
 
 /**
  * 랜딩 데모 페이지
@@ -15,10 +16,15 @@ const LandingDemo: React.FC = () => {
   const [error, setError] = useState('');
   const cardSectionRef = useRef<HTMLDivElement>(null);
 
-  const runSubmit = async (url: string) => {
+  const runSubmit = async (url: string, source: 'form' | 'example') => {
     setError('');
     setCards([]);
     setLoading(true);
+    if (source === 'form') {
+      trackEvent('landing_demo_generate', { source: 'form' });
+    } else {
+      trackEvent('landing_demo_example_repo', { repo_url: url.slice(0, 80) });
+    }
     try {
       const result = await generateDemoFlashcards(url);
       if (result.ok) {
@@ -38,7 +44,7 @@ const LandingDemo: React.FC = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    runSubmit(repoUrl);
+    runSubmit(repoUrl, 'form');
   };
 
   const EXAMPLE_REPOS = [
@@ -91,7 +97,7 @@ const LandingDemo: React.FC = () => {
             type="button"
             onClick={() => {
               setRepoUrl(url);
-              runSubmit(url);
+              runSubmit(url, 'example');
             }}
             disabled={loading}
             className={`inline-flex items-center justify-center h-11 min-h-[44px] w-[max-content] shrink-0 rounded-full text-[0.85rem] font-semibold border-0 transition-[opacity,filter] duration-200 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed hover:enabled:opacity-90 focus:outline focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-bg ${badge ? 'pl-4 pr-6' : 'px-4'}`}
@@ -137,7 +143,9 @@ const LandingDemo: React.FC = () => {
                 </p>
                 <a
                   href="/app"
+                  data-landing-action="get_started_free"
                   className="inline-flex items-center gap-2.5 py-3.5 px-8 bg-primary text-bg rounded-xl text-base font-bold no-underline transition-all duration-300 shadow-[0_8px_24px_rgba(7,166,107,0.2)] hover:-translate-y-0.5 hover:bg-primary-dark hover:shadow-[0_12px_36px_rgba(7,166,107,0.3)]"
+                  onClick={() => trackEvent('landing_demo_get_started_free', { from: 'after_demo' })}
                 >
                   Get Started Free
                 </a>

--- a/app/src/pages/Login.tsx
+++ b/app/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { signInWithPopup, signOut, GithubAuthProvider } from 'firebase/auth';
 import { doc, setDoc, updateDoc, getDoc, deleteDoc } from 'firebase/firestore';
 import { auth, githubProvider, store } from '../firebase';
+import { trackEvent } from '../analytics';
 
 const Login: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
@@ -77,6 +78,7 @@ const Login: React.FC = () => {
           });
         }
       }
+      trackEvent('login', { method: 'github' });
     } catch (error: any) {
       if (error.code === 'auth/popup-closed-by-user') {
         setError('로그인이 취소되었습니다.');

--- a/app/src/pages/Onboarding.tsx
+++ b/app/src/pages/Onboarding.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { doc, setDoc } from 'firebase/firestore';
 import { auth, store } from '../firebase';
+import { trackEvent } from '../analytics';
 import { getRepositories } from '../api/github-api';
 import { Repository } from '../types';
 
@@ -83,6 +84,8 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
         onboardingSkipped: false,
         updatedAt: new Date(),
       }, { merge: true });
+
+      trackEvent('onboarding_complete');
 
       // Step 3으로 이동
       setStep(3);


### PR DESCRIPTION
### Purpose

Firebase Analytics(GA4)를 연동해 퍼널·화면별 분석이 가능하도록 하고, 랜딩 페이지에서 스크롤/클릭 등 사용자 이벤트를 추적할 수 있게 한다. 클릭·스크롤 히트맵용으로 Microsoft Clarity 연동 방법을 추가한다.

### Description

**1. Firebase Analytics (GA4)**

| 파일 | 변경 내용 |
|------|------------|
| `app/src/firebase.ts` | `getAnalytics` 조건부 초기화, `analytics` export (measurementId·브라우저 있을 때만) |
| `app/src/analytics.ts` | 신규. `trackScreen()`, `trackEvent()` 헬퍼 (GA4 screen_view·커스텀 이벤트) |

**2. 앱 내 화면·퍼널 이벤트**

| 파일 | 변경 내용 |
|------|------------|
| `app/src/App.tsx` | 화면 변경 시 `screen_view` 1회 전송, `view_flashcard` / `view_settings` 전송 |
| `app/src/pages/Login.tsx` | 로그인 성공 시 `login` (method: github) |
| `app/src/pages/Onboarding.tsx` | 온보딩 완료 시 `onboarding_complete` |
| `app/src/features/flashcard/FlashCardPlayer.tsx` | 카드 뒤집기 시 `flashcard_flip` (card_index, total_cards) |

**3. 랜딩 페이지 이벤트**

| 파일 | 변경 내용 |
|------|------------|
| `app/src/landing-main.tsx` | 랜딩 `screen_view`, 스크롤 깊이 25/50/75/100% 시 `landing_scroll`, CTA 클릭 시 `landing_click` (클릭 위임) |
| `app/index.html` | 주요 CTA에 `data-landing-action` 추가 (get_started_nav, get_started_footer, nav_*, footer_* 등) |
| `app/src/pages/LandingDemo.tsx` | `landing_demo_generate`, `landing_demo_example_repo`, `landing_demo_get_started_free` 전송 |

**4. Microsoft Clarity (선택)**

| 파일 | 변경 내용 |
|------|------------|
| `app/src/main.tsx` | `VITE_CLARITY_PROJECT_ID` 있을 때만 Clarity 스크립트 동적 로드 |
| `app/.env.example` | `VITE_CLARITY_PROJECT_ID` 주석 예시 추가 |

**5. 환경 변수**

- 필수: `VITE_MEASUREMENT_ID` (기존 유지, GA4 전송용)
- 선택: `VITE_CLARITY_PROJECT_ID` (Clarity 히트맵·세션 녹화용)

### How to test

1. `.env`에 `VITE_MEASUREMENT_ID` 설정 후 `pnpm run dev`로 앱 실행.
2. **앱**: 로그인 → 온보딩 완료 → 플래시카드/설정 이동·카드 뒤집기 → GA4 실시간 보고서에서 `screen_view`, `login`, `onboarding_complete`, `view_flashcard`, `view_settings`, `flashcard_flip` 수신 확인.
3. **랜딩**: 루트(/) 접속 → 스크롤, Get Started·How it Works·Features·푸터 링크 클릭, 데모에서 Generate Cards·예시 repo·Get Started Free 클릭 → GA4에서 `landing_scroll`(depth), `landing_click`(action), `landing_demo_*` 수신 확인.
4. (선택) `.env`에 `VITE_CLARITY_PROJECT_ID=vlc4fqxduq` 추가 후 접속 → Clarity 대시보드에서 세션·히트맵 반영 여부 확인.

### Review Requirement

- `app/src/analytics.ts`에서 `screen_view` 타입 단언(`as Parameters<typeof logEvent>[1]`) 사용 부분: Firebase 타입이 엄격해 필요한 처리인지 한 번만 확인해 주시면 좋습니다.
- 랜딩 클릭 추적은 `data-landing-action`이 있는 요소만 `landing_click`으로 보내고, 없으면 `/app`·`#...` 링크는 action fallback으로 처리합니다. 의도한 CTA가 모두 수집되는지만 점검해 주세요.

### Additional Info

- GA4 퍼널·이벤트는 analytics.google.com → 탐색(Explore) / 참여 → 이벤트에서 확인. 이벤트는 한 번이라도 수집된 뒤부터 선택 가능하며, 퍼널 단계는 이벤트 이름 직접 입력 가능.
- Clarity 연동 방법·프로젝트 ID 설정은 Notion 「GA 연동」 문서 섹션 6에 정리되어 있습니다.