### PR TITLE
[TSK-123] Free/Pro 요금제 및 구독 기능 추가

### DIFF
--- a/.cursor/rules/pr-writing.mdc
+++ b/.cursor/rules/pr-writing.mdc
@@ -19,7 +19,13 @@ alwaysApply: false
 - **Description**: 수정/추가한 파일, 변경 요약, 유지한 설정 등을 구체적으로 나열한다. 필요 시 리스트·테이블을 활용한다.
 - **How to test**: 리뷰어가 로컬 또는 브라우저에서 확인할 수 있는 단계를 번호로 적는다.
 - **Review Requirement**: 리뷰어가 특히 꼼꼼히 봐줬으면 하는 부분을 적는다.
-- **Additional Info**: 이슈 번호, 관련 링크, 주의사항 등 보조 정보가 있으면 적는다.
+- **Additional Info**: 이슈 번호, **관련 Notion 페이지 링크**(필수), 그 외 관련 링크·주의사항 등 보조 정보가 있으면 적는다.
+
+## 2.5 Notion 링크 (필수)
+
+- PR 관련 문서를 작성할 때 **항상** 해당 작업과 연결된 **Notion 페이지 링크**를 PR 본문에 포함한다.
+- **위치**: Additional Info 섹션에 "관련 Notion: [페이지 제목](URL)" 형태로 넣는다. 필요 시 Description 상단에 넣어도 된다.
+- **URL 확보**: 대화 중 사용자가 공유한 Notion URL이 있으면 그대로 사용한다. 없으면 PR 본문에 `관련 Notion: (해당 작업 Notion 페이지 URL을 넣어 주세요)` 등 placeholder를 두고, 사용자에게 링크를 채우도록 안내한다.
 
 ## 3. PR 제목 (필수)
 

--- a/app/src/api/subscription-api.ts
+++ b/app/src/api/subscription-api.ts
@@ -1,0 +1,22 @@
+import { apiClient } from '../modules/axios';
+
+export type PriceId = 'monthly' | 'yearly';
+
+/**
+ * Stripe Checkout 세션 생성 후 리다이렉트 URL 반환
+ */
+export async function createCheckoutSession(priceId: PriceId, returnUrlBase?: string): Promise<{ url: string }> {
+  const { data } = await apiClient.post<{ url: string }>('/createCheckoutSession', {
+    priceId,
+    returnUrlBase: returnUrlBase || (typeof window !== 'undefined' ? window.location.origin : ''),
+  });
+  return data;
+}
+
+/**
+ * 오늘 플래시카드 수동 재생성 (Pro 전용, 일 3회 한도)
+ */
+export async function regenerateTodayFlashcards(): Promise<{ ok: boolean }> {
+  const { data } = await apiClient.post<{ ok: boolean }>('/regenerateTodayFlashcards', {});
+  return data;
+}

--- a/app/src/hooks/useSubscription.ts
+++ b/app/src/hooks/useSubscription.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { User } from 'firebase/auth';
+import { store } from '../firebase';
+import type { UserSubscription, SubscriptionTier } from '../types';
+
+const DEFAULT_TIER: SubscriptionTier = 'free';
+
+/**
+ * 사용자 구독·한도 정보 실시간 구독 (users/{uid})
+ * subscriptionTier, subscriptionPeriodEnd, regenerateCountToday, lastRegenerateDate, preferredPushHour
+ */
+export function useSubscription(user: User | null) {
+  const [subscription, setSubscription] = useState<UserSubscription | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (!user) {
+      setSubscription(null);
+      setLoading(false);
+      return;
+    }
+
+    const userRef = doc(store, 'users', user.uid);
+    const unsubscribe = onSnapshot(
+      userRef,
+      (snap) => {
+        if (!snap.exists()) {
+          setSubscription({ subscriptionTier: DEFAULT_TIER });
+          setLoading(false);
+          return;
+        }
+        const data = snap.data();
+        setSubscription({
+          subscriptionTier: (data.subscriptionTier === 'pro' ? 'pro' : 'free') as SubscriptionTier,
+          subscriptionPeriodEnd: data.subscriptionPeriodEnd ?? null,
+          stripeCustomerId: data.stripeCustomerId ?? null,
+          regenerateCountToday: typeof data.regenerateCountToday === 'number' ? data.regenerateCountToday : 0,
+          lastRegenerateDate: data.lastRegenerateDate ?? null,
+          preferredPushHour: typeof data.preferredPushHour === 'number' ? data.preferredPushHour : null,
+        });
+        setLoading(false);
+      },
+      (err) => {
+        console.error('useSubscription error:', err);
+        setSubscription({ subscriptionTier: DEFAULT_TIER });
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [user]);
+
+  return { subscription, loading };
+}

--- a/app/src/pages/PastDateReview.tsx
+++ b/app/src/pages/PastDateReview.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { FlashCardPlayer } from '../features/flashcard';
+import type { FlashCard } from '../features/flashcard';
+import { auth, store } from '../firebase';
+import { useNavigationStore } from '../stores/navigationStore';
+
+interface PastDateReviewProps {
+  date: string;
+}
+
+const PastDateReview: React.FC<PastDateReviewProps> = ({ date }) => {
+  const [cards, setCards] = useState<FlashCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const setSelectedPastDate = useNavigationStore((s) => s.setSelectedPastDate);
+
+  useEffect(() => {
+    const user = auth.currentUser;
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    const ref = doc(store, 'users', user.uid, 'flashcards', date);
+    getDoc(ref).then((snap) => {
+      setCards(snap.exists() ? (snap.data().data || []) : []);
+      setLoading(false);
+    });
+  }, [date]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg p-5">
+        <div className="w-10 h-10 border-4 border-border border-t-primary rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (cards.length === 0) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-bg p-5 text-center">
+        <p className="text-text-body text-[1rem] font-medium mb-1">해당 날짜에 저장된 카드가 없습니다.</p>
+        <p className="text-text-muted text-[0.9rem] mb-6">{date}</p>
+        <button
+          type="button"
+          onClick={() => setSelectedPastDate(null)}
+          className="py-2.5 px-5 bg-primary text-bg font-semibold rounded-lg border-none cursor-pointer transition-colors duration-200 hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-bg"
+        >
+          오늘로 돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-bg p-5 relative overflow-hidden before:content-[''] before:absolute before:-top-1/2 before:-left-1/2 before:w-[200%] before:h-[200%] before:bg-[radial-gradient(circle,rgba(7,166,107,0.04)_1px,transparent_1px)] before:bg-[length:50px_50px] before:animate-[float-bg_20s_linear_infinite] before:pointer-events-none max-[768px]:p-2.5">
+      <div className="text-center mb-2 relative z-[1] flex justify-center items-center gap-3">
+        <span className="text-text-light text-sm">{date} 복습</span>
+        <button
+          type="button"
+          onClick={() => setSelectedPastDate(null)}
+          className="py-1.5 px-3 bg-surface/90 text-text border border-border rounded-lg text-[0.85rem] font-medium transition-colors duration-200 hover:bg-surface-light focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-bg"
+        >
+          오늘로 돌아가기
+        </button>
+      </div>
+      <FlashCardPlayer cards={cards} keyboardShortcuts />
+    </div>
+  );
+};
+
+export default PastDateReview;

--- a/app/src/pages/Pricing.tsx
+++ b/app/src/pages/Pricing.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { createCheckoutSession, type PriceId } from '../api/subscription-api';
+
+const Pricing: React.FC = () => {
+  const [loading, setLoading] = useState<'monthly' | 'yearly' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCheckout = async (priceId: PriceId) => {
+    setError(null);
+    setLoading(priceId);
+    try {
+      const base = typeof window !== 'undefined' ? window.location.origin : '';
+      const { url } = await createCheckoutSession(priceId, base);
+      if (url) window.location.href = url;
+      else setError('결제 URL을 받지 못했습니다.');
+    } catch (e: unknown) {
+      const message = e && typeof e === 'object' && 'response' in e
+        ? (e as { response?: { data?: { error?: string } } }).response?.data?.error
+        : (e instanceof Error ? e.message : '결제 시작에 실패했습니다.');
+      setError(message || '결제 시작에 실패했습니다.');
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex justify-center items-start bg-bg pt-20 px-5 pb-5">
+      <div className="bg-surface rounded-2xl p-10 max-w-[600px] w-full shadow-[0_20px_60px_rgba(0,0,0,0.4)] max-[768px]:p-6">
+        <h1 className="text-2xl font-bold text-text mb-2">요금제</h1>
+        <p className="text-text-body text-[0.95rem] mb-8 leading-relaxed">Free로 충분히 사용하거나, Pro로 더 많은 기능을 쓰세요.</p>
+
+        <div className="overflow-x-auto mb-8">
+          <table className="w-full border-collapse text-left text-[0.9rem]">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="py-3 pr-4 font-semibold text-text">기능</th>
+                <th className="py-3 px-4 font-semibold text-text">Free</th>
+                <th className="py-3 pl-4 font-semibold text-primary">Pro</th>
+              </tr>
+            </thead>
+            <tbody className="text-text-body">
+              <tr className="border-b border-border">
+                <td className="py-2.5 pr-4">리포지토리</td>
+                <td className="py-2.5 px-4">1개</td>
+                <td className="py-2.5 pl-4">5개</td>
+              </tr>
+              <tr className="border-b border-border">
+                <td className="py-2.5 pr-4">복습 기간</td>
+                <td className="py-2.5 px-4">7일</td>
+                <td className="py-2.5 pl-4">30일·90일</td>
+              </tr>
+              <tr className="border-b border-border">
+                <td className="py-2.5 pr-4">수동 재생성</td>
+                <td className="py-2.5 px-4">—</td>
+                <td className="py-2.5 pl-4">3회/일</td>
+              </tr>
+              <tr className="border-b border-border">
+                <td className="py-2.5 pr-4">알림 시간</td>
+                <td className="py-2.5 px-4">08:00 고정</td>
+                <td className="py-2.5 pl-4">사용자 지정</td>
+              </tr>
+              <tr className="border-b border-border">
+                <td className="py-2.5 pr-4">과거 날짜 복습</td>
+                <td className="py-2.5 px-4">—</td>
+                <td className="py-2.5 pl-4">가능</td>
+              </tr>
+              <tr>
+                <td className="py-2.5 pr-4">내보내기</td>
+                <td className="py-2.5 px-4">—</td>
+                <td className="py-2.5 pl-4">가능</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 mb-6 max-[480px]:grid-cols-1">
+          <div className="border-2 border-border rounded-xl p-5 bg-surface-light transition-shadow duration-200 hover:shadow-[0_8px_24px_rgba(0,0,0,0.25)]">
+            <p className="font-bold text-text text-lg mb-1">월간</p>
+            <p className="text-text-light text-sm mb-4">$6/월 · ₩7,900/월</p>
+            <button
+              type="button"
+              disabled={!!loading}
+              onClick={() => handleCheckout('monthly')}
+              className="w-full py-3 px-4 bg-primary text-bg font-semibold rounded-lg border-none cursor-pointer transition-colors duration-200 hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {loading === 'monthly' ? '이동 중...' : '월간 구독'}
+            </button>
+          </div>
+          <div className="border-2 border-primary rounded-xl p-5 bg-surface-light transition-shadow duration-200 hover:shadow-[0_8px_24px_rgba(7,166,107,0.2)]">
+            <p className="font-bold text-primary text-lg mb-1">연간</p>
+            <p className="text-text-light text-sm mb-4">$58/년 · ₩76,000/년</p>
+            <button
+              type="button"
+              disabled={!!loading}
+              onClick={() => handleCheckout('yearly')}
+              className="w-full py-3 px-4 bg-primary text-bg font-semibold rounded-lg border-none cursor-pointer transition-colors duration-200 hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {loading === 'yearly' ? '이동 중...' : '연간 구독'}
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="p-4 rounded-lg bg-error-bg text-error-text border border-error/30 text-[0.9rem] mb-4" role="alert">
+            {error}
+          </div>
+        )}
+
+        <p className="text-text-muted text-[0.85rem] leading-relaxed">
+          결제는 Stripe를 통해 안전하게 처리됩니다. 세금·부가세는 결제 수단에 따라 적용될 수 있습니다.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Pricing;

--- a/app/src/stores/navigationStore.ts
+++ b/app/src/stores/navigationStore.ts
@@ -1,19 +1,25 @@
 import { create } from 'zustand';
 
-export type Page = 'flashcard' | 'settings';
+export type Page = 'flashcard' | 'settings' | 'pricing';
 
 interface NavigationState {
   currentPage: Page;
   flashcardReloadTrigger: number;
+  selectedPastDate: string | null;
   setCurrentPage: (page: Page) => void;
+  setSelectedPastDate: (date: string | null) => void;
   navigateToSettings: () => void;
   navigateToFlashcard: () => void;
+  navigateToPricing: () => void;
 }
 
 export const useNavigationStore = create<NavigationState>((set) => ({
   currentPage: 'flashcard',
   flashcardReloadTrigger: 0,
+  selectedPastDate: null,
   setCurrentPage: (page) => set({ currentPage: page }),
+  setSelectedPastDate: (date) => set({ selectedPastDate: date }),
   navigateToSettings: () => set({ currentPage: 'settings' }),
-  navigateToFlashcard: () => set({ currentPage: 'flashcard' })
+  navigateToFlashcard: () => set({ currentPage: 'flashcard' }),
+  navigateToPricing: () => set({ currentPage: 'pricing' }),
 }));

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -22,6 +22,23 @@ export interface Repository {
 }
 
 /**
+ * 구독 티어 (Firestore users/{uid} subscriptionTier와 동기화)
+ */
+export type SubscriptionTier = "free" | "pro";
+
+/**
+ * 사용자 구독·한도 정보 (Firestore users 문서 일부)
+ */
+export interface UserSubscription {
+  subscriptionTier: SubscriptionTier;
+  subscriptionPeriodEnd?: string | null;
+  stripeCustomerId?: string | null;
+  regenerateCountToday?: number;
+  lastRegenerateDate?: string | null;
+  preferredPushHour?: number | null;
+}
+
+/**
  * CLOVA Studio Chat Completion API Response
  */
 export interface ChatCompletionResponse {

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "firebase-admin": "^12.6.0",
-    "firebase-functions": "^6.0.1"
+    "firebase-functions": "^6.0.1",
+    "stripe": "^20.3.1"
   },
   "devDependencies": {
     "@types/node": "22.10.2",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,3 +11,5 @@ export * from "./github.js";
 export * from "./schedule.js";
 export * from "./clova.js";
 export * from "./openai.js";
+// TODO: Stripe 연동 시 아래 주석 해제
+// export * from "./stripe.js";

--- a/functions/src/stripe.ts
+++ b/functions/src/stripe.ts
@@ -1,0 +1,254 @@
+import {onRequest, HttpsError} from "firebase-functions/v2/https";
+import {getAuth} from "firebase-admin/auth";
+import {getFirestore} from "firebase-admin/firestore";
+import Stripe from "stripe";
+
+/** 로드 시점에 키가 없을 수 있으므로(에뮬레이터 등) 지연 초기화. 실제 호출 시 키 없으면 throw */
+let stripeInstance: Stripe | null = null;
+function getStripe(): Stripe {
+  if (stripeInstance) return stripeInstance;
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) throw new Error("STRIPE_SECRET_KEY is not set");
+  stripeInstance = new Stripe(key, {apiVersion: "2026-01-28.clover"});
+  return stripeInstance;
+}
+
+const db = getFirestore();
+
+/** KST 오늘 날짜 YYYY-MM-DD */
+function getTodayKST(): string {
+  const now = new Date();
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  return kst.toISOString().split("T")[0];
+}
+
+/**
+ * Firebase ID Token 검증 후 uid 반환
+ */
+async function getUidFromRequest(req: { headers: { authorization?: string } }): Promise<string> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    throw new HttpsError("unauthenticated", "ID token required.");
+  }
+  const idToken = authHeader.split("Bearer ")[1];
+  const decoded = await getAuth().verifyIdToken(idToken);
+  return decoded.uid;
+}
+
+/**
+ * Pro 체크아웃 세션 생성 (월간/연간)
+ * POST body: { priceId: 'monthly' | 'yearly', returnUrlBase: string }
+ */
+export const createCheckoutSession = onRequest(
+  {cors: true, region: "asia-northeast3", invoker: "public"},
+  async (req, res) => {
+    if (req.method !== "POST") {
+      res.status(405).json({error: "Method not allowed"});
+      return;
+    }
+    try {
+      const uid = await getUidFromRequest(req);
+      const {priceId, returnUrlBase} = req.body as { priceId?: string; returnUrlBase?: string };
+      const priceIdMonthly = process.env.STRIPE_PRICE_ID_MONTHLY;
+      const priceIdYearly = process.env.STRIPE_PRICE_ID_YEARLY;
+      if (!priceIdMonthly || !priceIdYearly) {
+        res.status(500).json({error: "Stripe price IDs not configured"});
+        return;
+      }
+      const stripePriceId = priceId === "yearly" ? priceIdYearly : priceIdMonthly;
+      const base = returnUrlBase || "https://coderecall.app";
+      const successUrl = `${base}/#settings?subscription=success`;
+      const cancelUrl = `${base}/#settings?subscription=cancel`;
+
+      const userDoc = await db.collection("users").doc(uid).get();
+      const userData = userDoc.exists ? userDoc.data() : {};
+      const stripeCustomerId = userData?.stripeCustomerId as string | undefined;
+      const email = (await getAuth().getUser(uid).catch(() => null))?.email;
+
+      const sessionParams: Stripe.Checkout.SessionCreateParams = {
+        mode: "subscription",
+        line_items: [{price: stripePriceId, quantity: 1}],
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+        client_reference_id: uid,
+        subscription_data: {
+          metadata: {firebase_uid: uid},
+        },
+      };
+      if (stripeCustomerId) {
+        sessionParams.customer = stripeCustomerId;
+      } else if (email) {
+        sessionParams.customer_email = email;
+      }
+
+      const session = await getStripe().checkout.sessions.create(sessionParams);
+      res.status(200).json({url: session.url});
+    } catch (e: unknown) {
+      if (e instanceof HttpsError) {
+        res.status(401).json({error: e.message});
+        return;
+      }
+      console.error("createCheckoutSession error:", e);
+      res.status(500).json({error: "Failed to create checkout session"});
+    }
+  }
+);
+
+/**
+ * Stripe 웹훅: checkout.session.completed, customer.subscription.updated/deleted
+ * rawBody 사용 (Firebase v2에서 가능한 경우). 없으면 body로 대체.
+ */
+export const stripeWebhook = onRequest(
+  {cors: false, region: "asia-northeast3", invoker: "public"},
+  async (req, res) => {
+    if (req.method !== "POST") {
+      res.status(405).end();
+      return;
+    }
+    const sig = req.headers["stripe-signature"];
+    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+    if (!webhookSecret || !sig) {
+      res.status(400).json({error: "Missing signature or webhook secret"});
+      return;
+    }
+    let rawBody: Buffer | string;
+    const raw = (req as unknown as { rawBody?: Buffer }).rawBody;
+    if (raw) {
+      rawBody = raw;
+    } else {
+      rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body || {});
+    }
+
+    let event: Stripe.Event;
+    try {
+      event = getStripe().webhooks.constructEvent(rawBody, sig, webhookSecret);
+    } catch (err) {
+      console.error("Webhook signature verification failed:", err);
+      res.status(400).json({error: "Invalid signature"});
+      return;
+    }
+
+    try {
+      switch (event.type) {
+        case "checkout.session.completed": {
+          const session = event.data.object as Stripe.Checkout.Session;
+          const uid = session.client_reference_id as string | null;
+          const subId = session.subscription as string | null;
+          if (!subId) break;
+          const sub = await getStripe().subscriptions.retrieve(subId);
+          const resolvedUid = uid || (sub.metadata as { firebase_uid?: string })?.firebase_uid;
+          if (resolvedUid) {
+            const customerId = typeof session.customer === "string" ? session.customer : session.customer?.id;
+            const periodEnd = (sub as unknown as { current_period_end: number }).current_period_end;
+            await setPro(resolvedUid, periodEnd, customerId);
+          }
+          break;
+        }
+        case "customer.subscription.updated":
+        case "customer.subscription.deleted": {
+          const sub = event.data.object as Stripe.Subscription;
+          const uid = (sub.metadata as { firebase_uid?: string })?.firebase_uid;
+          if (uid) {
+            if (sub.status === "active" || sub.status === "trialing") {
+              const periodEnd = (sub as unknown as { current_period_end: number }).current_period_end;
+              await setPro(uid, periodEnd, undefined);
+            } else {
+              await setFree(uid);
+            }
+          }
+          break;
+        }
+        default:
+          break;
+      }
+      res.status(200).json({received: true});
+    } catch (err) {
+      console.error("Webhook handler error:", err);
+      res.status(500).json({error: "Webhook handler failed"});
+    }
+  }
+);
+
+async function setPro(uid: string, periodEnd: number, stripeCustomerId?: string): Promise<void> {
+  const ref = db.collection("users").doc(uid);
+  const endDate = new Date(periodEnd * 1000).toISOString();
+  const update: Record<string, unknown> = {
+    subscriptionTier: "pro",
+    subscriptionPeriodEnd: endDate,
+    updatedAt: new Date().toISOString(),
+  };
+  if (stripeCustomerId) update.stripeCustomerId = stripeCustomerId;
+  await ref.set(update, {merge: true});
+}
+
+async function setFree(uid: string): Promise<void> {
+  await db.collection("users").doc(uid).set(
+    {
+      subscriptionTier: "free",
+      subscriptionPeriodEnd: null,
+      updatedAt: new Date().toISOString(),
+    },
+    {merge: true}
+  );
+}
+
+/**
+ * 수동 재생성 (Pro 전용, 일 3회 한도)
+ * POST. 인증 필수.
+ */
+export const regenerateTodayFlashcards = onRequest(
+  {cors: true, region: "asia-northeast3", invoker: "public"},
+  async (req, res) => {
+    if (req.method !== "POST") {
+      res.status(405).json({error: "Method not allowed"});
+      return;
+    }
+    try {
+      const uid = await getUidFromRequest(req);
+      const userRef = db.collection("users").doc(uid);
+      const userSnap = await userRef.get();
+      if (!userSnap.exists) {
+        res.status(404).json({error: "User not found"});
+        return;
+      }
+      const data = userSnap.data()!;
+      const tier = data.subscriptionTier || "free";
+      if (tier !== "pro") {
+        res.status(403).json({error: "Pro subscription required"});
+        return;
+      }
+
+      const today = getTodayKST();
+      let regenerateCountToday = typeof data.regenerateCountToday === "number" ? data.regenerateCountToday : 0;
+      const lastRegenerateDate = data.lastRegenerateDate as string | undefined;
+
+      if (lastRegenerateDate !== today) {
+        regenerateCountToday = 0;
+      }
+      if (regenerateCountToday >= 3) {
+        res.status(429).json({error: "Daily regenerate limit reached", limit: 3});
+        return;
+      }
+
+      const flashcardRef = db.collection("users").doc(uid).collection("flashcards").doc(today);
+      await flashcardRef.delete();
+      await userRef.set(
+        {
+          regenerateCountToday: regenerateCountToday + 1,
+          lastRegenerateDate: today,
+          updatedAt: new Date().toISOString(),
+        },
+        {merge: true}
+      );
+      res.status(200).json({ok: true});
+    } catch (e: unknown) {
+      if (e instanceof HttpsError) {
+        const status = e.code === "unauthenticated" ? 401 : 403;
+        res.status(status).json({error: e.message});
+        return;
+      }
+      console.error("regenerateTodayFlashcards error:", e);
+      res.status(500).json({error: "Regenerate failed"});
+    }
+  }
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       firebase-functions:
         specifier: ^6.0.1
         version: 6.5.0(firebase-admin@12.7.0(encoding@0.1.13))
+      stripe:
+        specifier: ^20.3.1
+        version: 20.3.1(@types/node@22.10.2)
     devDependencies:
       '@types/node':
         specifier: 22.10.2
@@ -4385,6 +4388,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@20.3.1:
+    resolution: {integrity: sha512-k990yOT5G5rhX3XluRPw5Y8RLdJDW4dzQ29wWT66piHrbnM2KyamJ1dKgPsw4HzGHRWjDiSSdcI2WdxQUPV3aQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@types/node': '>=16'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
@@ -10254,6 +10266,10 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  stripe@20.3.1(@types/node@22.10.2):
+    optionalDependencies:
+      '@types/node': 22.10.2
 
   strnum@1.1.2:
     optional: true


### PR DESCRIPTION
### Purpose

Stripe 연동 전까지 앱에서 Free/Pro 구독 티어를 구분하고, Pro 전용 기능(알림 시 선택, 플래시카드 재생성, 과거 날짜 복습)을 사용할 수 있도록 요금제·구독 관련 기능을 추가한다.

### Description

- **타입·데이터**
  - `app/src/types.ts`: `SubscriptionTier`, `UserSubscription` 타입 추가 (subscriptionTier, subscriptionPeriodEnd, stripeCustomerId, regenerateCountToday, lastRegenerateDate, preferredPushHour 등).
  - Firestore `users/{uid}` 문서에 구독·한도 필드 추가 (스키마 변경 문서화 완료).

- **백엔드 (Functions)**
  - `functions/src/stripe.ts`: `createCheckoutSession`, `stripeWebhook`, `regenerateTodayFlashcards` 구현. Stripe API 키 없이 모듈 로드되도록 지연 초기화(`getStripe()`) 적용.
  - `functions/src/schedule.ts`: 매시 정각 실행, `preferredPushHour`(KST)로 필터링해 Pro 사용자 맞춤 알림.
  - `functions/src/index.ts`: Stripe 연동 전까지 빌드에서 제외하기 위해 `export * from "./stripe.js"` 주석 처리 (TODO 주석 포함).

- **프론트엔드**
  - `useSubscription(currentUser)`: `users/{uid}` 실시간 구독·한도 상태 구독.
  - `useTodayFlashcards`: Free는 1·7일 전, Pro는 1·7·30일 전 커밋 기준으로 플래시카드 생성.
  - `app/src/api/subscription-api.ts`: `createCheckoutSession`, `regenerateTodayFlashcards` 호출.
  - **Settings**: 구독 카드(Free/Pro·만료일), Pro 업그레이드 버튼(현재 "준비 중" alert, TODO: `navigateToPricing` 복구), Pro 전용 알림 시 선택·재생성(일 3회)·과거 날짜 복습(날짜 입력 → 해당 날짜 카드 보기).
  - **Pricing**: 요금 비교 테이블, 월간/연간 버튼(Stripe Checkout 연동 후 사용). transition·focus ring·카드 호버 등 UI 개선.
  - **PastDateReview**: `selectedPastDate`일 때 `users/{uid}/flashcards/{date}` 로드 후 FlashCardPlayer로 재생. 빈 상태 문구·포커스 링 정리.
  - **네비게이션**: `navigationStore`에 `pricing`, `selectedPastDate`/`setSelectedPastDate` 추가. App에서 pricing·PastDateReview 라우팅, Stripe 복귀 시 `#settings?subscription=success` 처리.

- **UI/UX**
  - Pricing·Settings·PastDateReview 버튼/입력에 `transition-colors duration-200`, `focus:ring-2 focus:ring-primary` 등 적용. select/date input 포커스 스타일 통일.

- **문서·Notion**
  - 요금제 기능·Firestore 스키마 변경·Pro/Free 수동 설정 가이드를 Notion Free/Pro 페이지에 정리.

### How to test

1. 로그인 후 **설정**에서 구독 카드에 "Free" 표시 확인.
2. Firestore `users/{본인 uid}`에 `subscriptionTier: "pro"`, `subscriptionPeriodEnd: "2026-12-31T23:59:59.000Z"`, `updatedAt`(ISO) 추가 후 새로고침 → 설정에 "Pro"·만료일, 알림 시 선택·재생성·과거 날짜 복습 블록 노출 확인.
3. **과거 날짜 복습**: 날짜 선택 → "해당 날짜 카드 보기" → 해당 날짜 플래시카드 로드 및 재생, "오늘로 돌아가기" 동작 확인.
4. **Pro로 업그레이드** 버튼 클릭 → "Pro 업그레이드는 준비 중이에요..." alert 확인.
5. (선택) Pricing 페이지 진입 후 월간/연간 카드 호버·포커스 링·반응형(좁은 화면에서 1열) 확인.

### Review Requirement

- Firestore `users/{uid}` 구독 필드 타입: `preferredPushHour`, `regenerateCountToday`는 number, `subscriptionPeriodEnd`/`lastRegenerateDate`는 string 또는 null로 사용 중인지 확인.
- Stripe 미연동 상태에서 Pro 전용 Functions(`regenerateTodayFlashcards`) 호출 시 404/500이 나는 것이 기대 동작인지 확인(현재 index에서 stripe export 제외됨).

### Additional Info

- Stripe 연동 시: `functions/src/index.ts`에서 `// export * from "./stripe.js"` 주석 해제, 환경 변수(`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, Price ID) 설정 필요.
- Pro 업그레이드 버튼 복구: Settings.tsx에서 TODO 주석 참고해 `onClick`을 `navigateToPricing`으로 변경.
- 관련 문서: Notion Free/Pro 요금제 페이지(스키마·수동 설정 가이드 포함).