### PR TITLE
[TSK-124] 다중 레포 지원 및 플래시카드 레이아웃·모바일 UX 개선

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -60,8 +60,8 @@ const App: React.FC = () => {
           setNeedsOnboarding(true);
         } else {
           const data = userDoc.data();
-          // onboardingCompleted가 true이거나 repositoryFullName이 있으면 온보딩 불필요
-          if (data?.onboardingCompleted || data?.repositoryFullName) {
+          // onboardingCompleted가 true이거나 repositories가 있으면 온보딩 불필요
+          if (data?.onboardingCompleted || (Array.isArray(data?.repositories) && data.repositories.length > 0)) {
             setNeedsOnboarding(false);
           } else {
             setNeedsOnboarding(true);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -155,8 +155,9 @@ const App: React.FC = () => {
   return (
     <>
       <main>
-        <nav className={`fixed top-0 left-0 right-0 bg-transparent z-[1000] px-5 py-3 flex justify-between items-center transition-all duration-300 ease-in-out ${isScrollAtTop ? 'opacity-100 translate-y-0 pointer-events-auto' : 'opacity-0 -translate-y-5 pointer-events-none'}`}>
-          <div>
+        {/* 플로팅 navbar: transparent 영역은 pointer-events-none으로 아래 콘텐츠 클릭 통과, 버튼만 pointer-events-auto (ui-ux-pro-max: Content padding, Floating navbar) */}
+        <nav className={`fixed top-4 left-4 right-4 max-[768px]:top-2 max-[768px]:left-2 max-[768px]:right-2 bg-transparent z-[1000] px-5 py-3 max-[768px]:py-2 max-[768px]:px-3 flex justify-between items-center transition-all duration-300 ease-in-out pointer-events-none ${isScrollAtTop ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-5'}`}>
+          <div className={isScrollAtTop ? 'pointer-events-auto' : 'pointer-events-none'}>
             {(currentPage === 'settings' || currentPage === 'pricing') && (
               <button
                 onClick={currentPage === 'pricing' ? navigateToSettings : navigateToFlashcard}
@@ -168,20 +169,25 @@ const App: React.FC = () => {
           </div>
 
           {currentPage === 'flashcard' && (
-            <button
-              onClick={navigateToSettings}
-              className="py-2 px-4 bg-surface/95 text-text border border-border rounded-lg cursor-pointer text-[1.2rem] transition-all duration-200 shadow-[0_2px_8px_rgba(0,0,0,0.3)] backdrop-blur-sm hover:bg-surface-light hover:-translate-y-px hover:shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
-              title="설정"
-            >
-              ⚙️
-            </button>
+            <div className={isScrollAtTop ? 'pointer-events-auto' : 'pointer-events-none'}>
+              <button
+                onClick={navigateToSettings}
+                className="py-2 px-4 bg-surface/95 text-text border border-border rounded-lg cursor-pointer text-[1.2rem] transition-all duration-200 shadow-[0_2px_8px_rgba(0,0,0,0.3)] backdrop-blur-sm hover:bg-surface-light hover:-translate-y-px hover:shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
+                title="설정"
+              >
+                ⚙️
+              </button>
+            </div>
           )}
         </nav>
 
-        <div>
-          {currentPage === 'flashcard' && (selectedPastDate ? <PastDateReview date={selectedPastDate} /> : <FlashCardViewer />)}
-          {currentPage === 'settings' && <Settings />}
-          {currentPage === 'pricing' && <Pricing />}
+        {/* 뷰포트 높이로 제한해 패딩+콘텐츠가 100vh를 넘지 않게 (모바일 세로 스크롤 방지) */}
+        <div className="pt-16 max-[768px]:pt-12 bg-bg h-screen flex flex-col overflow-hidden">
+          <div className="flex-1 min-h-0 overflow-auto">
+            {currentPage === 'flashcard' && (selectedPastDate ? <PastDateReview date={selectedPastDate} /> : <FlashCardViewer />)}
+            {currentPage === 'settings' && <Settings />}
+            {currentPage === 'pricing' && <Pricing />}
+          </div>
         </div>
       </main>
     </>

--- a/app/src/api/github-api.ts
+++ b/app/src/api/github-api.ts
@@ -36,30 +36,40 @@ interface MarkdownResponse {
   content: string;
 }
 
-export async function getCommits(since: Date, until: Date): Promise<Commit[]> {
-  const sinceISO = since.toISOString();
-  const untilISO = until.toISOString();
-  
-  const response = await apiClient.get('/getCommits', {
-    params: { since: sinceISO, until: untilISO }
-  });
-  
+export async function getCommits(
+  since: Date,
+  until: Date,
+  repositoryFullName?: string
+): Promise<Commit[]> {
+  const params: Record<string, string> = {
+    since: since.toISOString(),
+    until: until.toISOString(),
+  };
+  if (repositoryFullName) params.repositoryFullName = repositoryFullName;
+
+  const response = await apiClient.get('/getCommits', { params });
   return response.data;
 }
 
-export async function getFilename(sha: string): Promise<CommitDetail> {
-  const response = await apiClient.get('/getFilename', {
-    params: { commit_sha: sha }
-  });
-  
+export async function getFilename(
+  sha: string,
+  repositoryFullName?: string
+): Promise<CommitDetail> {
+  const params: Record<string, string> = { commit_sha: sha };
+  if (repositoryFullName) params.repositoryFullName = repositoryFullName;
+
+  const response = await apiClient.get('/getFilename', { params });
   return response.data;
 }
 
-export async function getMarkdown(filename: string): Promise<string> {
-  const response = await apiClient.get('/getMarkdown', {
-    params: { filename }
-  });
-  
+export async function getMarkdown(
+  filename: string,
+  repositoryFullName?: string
+): Promise<string> {
+  const params: Record<string, string> = { filename };
+  if (repositoryFullName) params.repositoryFullName = repositoryFullName;
+
+  const response = await apiClient.get('/getMarkdown', { params });
   const data: MarkdownResponse = response.data;
   return data.content;
 }

--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -147,7 +147,7 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
     setFileError(null);
     const fetchPromise = currentRawUrl
       ? getFileContent(currentRawUrl)
-      : getMarkdown(currentFilename);
+      : getMarkdown(currentFilename, card?.metadata?.repositoryFullName);
     fetchPromise
       .then((content) => {
         if (!cancelled) {
@@ -292,11 +292,25 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                   {isFlipped ? (
                     <div className="fc-card-back w-full h-full flex flex-col min-h-0">
                       <div
-                        className="fc-back-header flex items-center gap-1 p-2 border-b border-slate-200 bg-slate-50 shrink-0 rounded-t-3xl"
+                        className="fc-back-header flex flex-wrap items-center gap-1 p-2 border-b border-slate-200 bg-slate-50 shrink-0 rounded-t-3xl"
                         onClick={(e) => e.stopPropagation()}
                         role="tablist"
                         aria-label="뒷면 보기 모드"
                       >
+                        {card.metadata?.repositoryFullName && (
+                          <a
+                            href={`https://github.com/${card.metadata.repositoryFullName}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1.5 mr-2 px-2 py-1 rounded-lg bg-white border border-slate-200 text-[0.75rem] font-mono text-slate-600 no-underline transition-colors duration-200 hover:bg-slate-100 hover:border-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5 shrink-0" aria-hidden>
+                              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                            </svg>
+                            <span className="truncate max-w-[140px] sm:max-w-[200px]" title={card.metadata.repositoryFullName}>{card.metadata.repositoryFullName}</span>
+                          </a>
+                        )}
                         <button
                           type="button"
                           role="tab"
@@ -370,6 +384,14 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                     </div>
                   ) : (
                     <div className="flex flex-col items-center justify-center w-full p-4 text-center">
+                      {card.metadata?.repositoryFullName && (
+                        <span className="inline-flex items-center gap-1.5 mb-2 px-2.5 py-1 rounded-lg bg-slate-100 border border-slate-200 text-[0.75rem] font-mono text-slate-600">
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5 shrink-0" aria-hidden>
+                            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                          </svg>
+                          <span className="truncate max-w-[200px] sm:max-w-[280px]" title={card.metadata.repositoryFullName}>{card.metadata.repositoryFullName}</span>
+                        </span>
+                      )}
                       <span className="inline-block mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
                         질문
                       </span>

--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -40,6 +40,10 @@ export interface FlashCardPlayerProps {
   keyboardShortcuts?: boolean;
   renderHeader?: () => React.ReactNode;
   renderFooter?: () => React.ReactNode;
+  /** 슬라이드 변경 시 호출 (모바일에서 상단 인디케이터 연동용) */
+  onSlideChange?: (index: number) => void;
+  /** 제공 시 기본 인디케이터 대신 사용 (모바일에서 뷰어와 한 줄로 묶을 때) */
+  renderIndicator?: (current: number, total: number) => React.ReactNode;
 }
 
 const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
@@ -47,6 +51,8 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
   keyboardShortcuts = false,
   renderHeader,
   renderFooter,
+  onSlideChange,
+  renderIndicator,
 }) => {
   const [flipped, setFlipped] = useState(false);
   const [currentSlide, setCurrentSlide] = useState(0);
@@ -241,11 +247,15 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
 
       {renderHeader?.()}
 
-      <div className="text-center mb-4">
-        <span className="inline-block bg-surface py-2.5 px-[22px] rounded-full shadow-[0_8px_20px_rgba(0,0,0,0.3)] text-[0.95rem] font-semibold text-primary backdrop-blur-[10px] border border-border animate-[fc-slide-down_0.5s_ease-out] max-[768px]:py-2 max-[768px]:px-[18px] max-[768px]:text-[0.85rem]">
-          {currentSlide + 1} / {cards.length}
-        </span>
-      </div>
+      {renderIndicator ? (
+        renderIndicator(currentSlide, cards.length) ?? <div className="mb-4" aria-hidden />
+      ) : (
+        <div className="text-center mb-4">
+          <span className="inline-block bg-surface py-2.5 px-[22px] rounded-full shadow-[0_8px_20px_rgba(0,0,0,0.3)] text-[0.95rem] font-semibold text-primary backdrop-blur-[10px] border border-border animate-[fc-slide-down_0.5s_ease-out] max-[768px]:py-2 max-[768px]:px-[18px] max-[768px]:text-[0.85rem]">
+            {currentSlide + 1} / {cards.length}
+          </span>
+        </div>
+      )}
 
       <div className="fc-player flex-1 flex flex-col min-h-0 max-w-[1200px] mx-auto w-full relative z-10">
         <div className="flex-1 min-h-0 flex flex-col">
@@ -263,6 +273,7 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
               setFileError(null);
               lastFetchedUrlRef.current = null;
               setCurrentSlide(next);
+              onSlideChange?.(next);
             }}
             appendDots={(dots) => (
               <div style={{ top: '10px' }}>

--- a/app/src/features/flashcard/types.ts
+++ b/app/src/features/flashcard/types.ts
@@ -12,5 +12,7 @@ export interface FlashCard {
     /** 전체 파일 목록 (raw_url 등) */
     files?: FileChange[];
     filename?: string;
+    /** 카드 출처 레포 (owner/repo). 다중 레포 시 표시용 */
+    repositoryFullName?: string;
   };
 }

--- a/app/src/modules/utils.ts
+++ b/app/src/modules/utils.ts
@@ -5,3 +5,13 @@
 export function getCurrentDate(): string {
   return new Date().toLocaleDateString('en-CA');
 }
+
+/** Fisher-Yates 셔플. 덱 순서를 무작위로 바꾼 새 배열 반환 (원본 불변). */
+export function shuffleArray<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}

--- a/app/src/pages/FlashCardViewer.tsx
+++ b/app/src/pages/FlashCardViewer.tsx
@@ -1,17 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { doc, getDoc } from 'firebase/firestore';
 
 import { FlashCardPlayer } from '../features/flashcard';
 import type { FlashCard } from '../features/flashcard';
 import { auth, store } from '../firebase';
-import { getCurrentDate } from '../modules/utils';
+import { getCurrentDate, shuffleArray } from '../modules/utils';
 
 /**
  * 로그인 사용자 전용 플래시카드 뷰어
  * 데이터 소스: Firestore (users/{uid}/flashcards/{오늘날짜}). 데모는 LandingDemo + lib/demoFlashcards.
+ * 진입 시 1회 셔플, "덱 셔플" 버튼으로 순서 재섞기.
  */
 const FlashCardViewer: React.FC = () => {
   const [cards, setCards] = useState<FlashCard[]>([]);
+  const [shuffleKey, setShuffleKey] = useState(0);
 
   useEffect(() => {
     const user = auth.currentUser;
@@ -23,11 +25,17 @@ const FlashCardViewer: React.FC = () => {
     getDoc(flashcardDocRef).then((snapshot) => {
       if (snapshot.exists()) {
         const data = snapshot.data();
-        setCards(data.data || []);
+        const raw = (data?.data || []) as FlashCard[];
+        setCards(shuffleArray(raw));
       } else {
         setCards([]);
       }
     });
+  }, []);
+
+  const handleShuffleDeck = useCallback(() => {
+    setCards((prev) => shuffleArray(prev));
+    setShuffleKey((k) => k + 1);
   }, []);
 
   if (cards.length === 0) {
@@ -37,11 +45,12 @@ const FlashCardViewer: React.FC = () => {
   return (
     <div className="min-h-screen flex flex-col bg-bg p-5 relative overflow-hidden before:content-[''] before:absolute before:-top-1/2 before:-left-1/2 before:w-[200%] before:h-[200%] before:bg-[radial-gradient(circle,rgba(7,166,107,0.04)_1px,transparent_1px)] before:bg-[length:50px_50px] before:animate-[float-bg_20s_linear_infinite] before:pointer-events-none max-[768px]:p-2.5">
       <FlashCardPlayer
+        key={shuffleKey}
         cards={cards}
         keyboardShortcuts
         renderHeader={() => (
-          <div className="text-center mb-2 relative z-[1] max-[768px]:hidden">
-            <div className="inline-flex bg-surface/90 px-5 py-2.5 rounded-[20px] shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] text-text-light backdrop-blur-sm gap-4 items-center border border-border animate-fade-in">
+          <div className="flex flex-wrap justify-center gap-3 mb-2 relative z-[1] max-[768px]:gap-2">
+            <div className="inline-flex bg-surface/90 px-5 py-2.5 rounded-[20px] shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] text-text-light backdrop-blur-sm gap-4 items-center border border-border animate-fade-in max-[768px]:hidden">
               <div className="flex items-center gap-1.5">
                 <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">&larr;</kbd>
                 <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">&rarr;</kbd>
@@ -52,6 +61,23 @@ const FlashCardViewer: React.FC = () => {
                 <span>뒤집기</span>
               </div>
             </div>
+            <button
+              type="button"
+              onClick={handleShuffleDeck}
+              aria-label="덱 순서 섞기"
+              className="inline-flex items-center gap-2 px-4 py-2.5 rounded-[20px] bg-surface/90 border border-border shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] font-medium text-text-light backdrop-blur-sm transition-colors duration-200 hover:bg-surface-light hover:border-border-medium hover:text-text cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5 shrink-0" aria-hidden>
+                <path d="M16 3h5v5" />
+                <path d="M8 3H3v5" />
+                <path d="M12 22v-8.3a4 4 0 0 0-1.172-2.872L3 3" />
+                <path d="m15 9 6-6" />
+                <path d="M9 21H4v-5" />
+                <path d="M21 21v-5h-5" />
+                <path d="m15 15 6 6" />
+              </svg>
+              <span>덱 셔플</span>
+            </button>
           </div>
         )}
       />

--- a/app/src/pages/FlashCardViewer.tsx
+++ b/app/src/pages/FlashCardViewer.tsx
@@ -1,4 +1,18 @@
 import React, { useEffect, useState, useCallback } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const m = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
+    setIsMobile(m.matches);
+    const handler = () => setIsMobile(m.matches);
+    m.addEventListener('change', handler);
+    return () => m.removeEventListener('change', handler);
+  }, []);
+  return isMobile;
+}
 import { doc, getDoc } from 'firebase/firestore';
 
 import { FlashCardPlayer } from '../features/flashcard';
@@ -14,6 +28,8 @@ import { getCurrentDate, shuffleArray } from '../modules/utils';
 const FlashCardViewer: React.FC = () => {
   const [cards, setCards] = useState<FlashCard[]>([]);
   const [shuffleKey, setShuffleKey] = useState(0);
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     const user = auth.currentUser;
@@ -42,45 +58,59 @@ const FlashCardViewer: React.FC = () => {
     return null;
   }
 
+  const indicatorPillClass =
+      'items-center justify-center bg-surface py-2 px-[18px] rounded-full shadow-[0_8px_20px_rgba(0,0,0,0.3)] text-[0.85rem] font-semibold text-primary backdrop-blur-[10px] border border-border';
+    const shuffleBtnClass =
+      'inline-flex items-center gap-2 px-4 py-2 rounded-[20px] bg-surface/90 border border-border shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] font-medium text-text-light backdrop-blur-sm transition-colors duration-200 hover:bg-surface-light hover:border-border-medium hover:text-text cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg';
+
   return (
-    <div className="min-h-screen flex flex-col bg-bg p-5 relative overflow-hidden before:content-[''] before:absolute before:-top-1/2 before:-left-1/2 before:w-[200%] before:h-[200%] before:bg-[radial-gradient(circle,rgba(7,166,107,0.04)_1px,transparent_1px)] before:bg-[length:50px_50px] before:animate-[float-bg_20s_linear_infinite] before:pointer-events-none max-[768px]:p-2.5">
-      <FlashCardPlayer
-        key={shuffleKey}
-        cards={cards}
-        keyboardShortcuts
-        renderHeader={() => (
-          <div className="flex flex-wrap justify-center gap-3 mb-2 relative z-[1] max-[768px]:gap-2">
-            <div className="inline-flex bg-surface/90 px-5 py-2.5 rounded-[20px] shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] text-text-light backdrop-blur-sm gap-4 items-center border border-border animate-fade-in max-[768px]:hidden">
-              <div className="flex items-center gap-1.5">
-                <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">&larr;</kbd>
-                <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">&rarr;</kbd>
-                <span>이동</span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">Space</kbd>
-                <span>뒤집기</span>
-              </div>
+    <div className="min-h-full flex flex-col bg-bg p-5 relative overflow-hidden before:content-[''] before:absolute before:-top-1/2 before:-left-1/2 before:w-[200%] before:h-[200%] before:bg-[radial-gradient(circle,rgba(7,166,107,0.04)_1px,transparent_1px)] before:bg-[length:50px_50px] before:animate-[float-bg_20s_linear_infinite] before:pointer-events-none max-[768px]:p-2.5 max-[768px]:justify-center">
+      {/* 모바일: 인디케이터+셔플+카드 영역을 한 블록으로 묶어 세로 가운데 배치 */}
+      <div className="flex flex-col max-[768px]:flex-shrink-0 max-[768px]:w-full">
+        {/* 데스크톱: 키보드 안내 + 셔플 | 모바일: 인디케이터 + 셔플 한 줄 (설정 버튼은 App nav에 있음) */}
+        <div className="flex flex-wrap justify-center gap-3 mb-2 relative z-[100] max-[768px]:gap-2 max-[768px]:justify-between max-[768px]:items-center max-[768px]:mb-3 shrink-0">
+          <div className="inline-flex bg-surface/90 px-5 py-2.5 rounded-[20px] shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] text-text-light backdrop-blur-sm gap-4 items-center border border-border animate-fade-in max-[768px]:hidden">
+            <div className="flex items-center gap-1.5">
+              <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">&larr;</kbd>
+              <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">&rarr;</kbd>
+              <span>이동</span>
             </div>
-            <button
-              type="button"
-              onClick={handleShuffleDeck}
-              aria-label="덱 순서 섞기"
-              className="inline-flex items-center gap-2 px-4 py-2.5 rounded-[20px] bg-surface/90 border border-border shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] font-medium text-text-light backdrop-blur-sm transition-colors duration-200 hover:bg-surface-light hover:border-border-medium hover:text-text cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5 shrink-0" aria-hidden>
-                <path d="M16 3h5v5" />
-                <path d="M8 3H3v5" />
-                <path d="M12 22v-8.3a4 4 0 0 0-1.172-2.872L3 3" />
-                <path d="m15 9 6-6" />
-                <path d="M9 21H4v-5" />
-                <path d="M21 21v-5h-5" />
-                <path d="m15 15 6 6" />
-              </svg>
-              <span>덱 셔플</span>
-            </button>
+            <div className="flex items-center gap-1.5">
+              <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">Space</kbd>
+              <span>뒤집기</span>
+            </div>
           </div>
-        )}
-      />
+          {/* 모바일만: 인디케이터 + 셔플 한 줄 (동일 pill 스타일로 조화). 데스크톱에서는 hidden만 적용되도록 inline-flex는 768 이하에서만 */}
+          <span className={`hidden max-[768px]:inline-flex max-[768px]:order-first ${indicatorPillClass}`} aria-live="polite">
+            {currentSlide + 1} / {cards.length}
+          </span>
+          <button
+            type="button"
+            onClick={handleShuffleDeck}
+            aria-label="덱 순서 섞기"
+            className={`${shuffleBtnClass} max-[768px]:order-last`}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5 shrink-0" aria-hidden>
+              <path d="M16 3h5v5" />
+              <path d="M8 3H3v5" />
+              <path d="M12 22v-8.3a4 4 0 0 0-1.172-2.872L3 3" />
+              <path d="m15 9 6-6" />
+              <path d="M9 21H4v-5" />
+              <path d="M21 21v-5h-5" />
+              <path d="m15 15 6 6" />
+            </svg>
+            <span>덱 셔플</span>
+          </button>
+        </div>
+
+        <FlashCardPlayer
+          key={shuffleKey}
+          cards={cards}
+          keyboardShortcuts
+          onSlideChange={setCurrentSlide}
+          renderIndicator={isMobile ? () => null : undefined}
+        />
+      </div>
     </div>
   );
 };

--- a/app/src/pages/PastDateReview.tsx
+++ b/app/src/pages/PastDateReview.tsx
@@ -52,7 +52,7 @@ const PastDateReview: React.FC<PastDateReviewProps> = ({ date }) => {
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-bg p-5 relative overflow-hidden before:content-[''] before:absolute before:-top-1/2 before:-left-1/2 before:w-[200%] before:h-[200%] before:bg-[radial-gradient(circle,rgba(7,166,107,0.04)_1px,transparent_1px)] before:bg-[length:50px_50px] before:animate-[float-bg_20s_linear_infinite] before:pointer-events-none max-[768px]:p-2.5">
+    <div className="min-h-full flex flex-col bg-bg p-5 relative overflow-hidden before:content-[''] before:absolute before:-top-1/2 before:-left-1/2 before:w-[200%] before:h-[200%] before:bg-[radial-gradient(circle,rgba(7,166,107,0.04)_1px,transparent_1px)] before:bg-[length:50px_50px] before:animate-[float-bg_20s_linear_infinite] before:pointer-events-none max-[768px]:p-2.5">
       <div className="text-center mb-2 relative z-[1] flex justify-center items-center gap-3">
         <span className="text-text-light text-sm">{date} 복습</span>
         <button

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -10,7 +10,7 @@ export interface FlashcardStructuredOutput {
 }
 
 /**
- * GitHub Repository
+ * GitHub Repository (API 응답)
  */
 export interface Repository {
   id: number;
@@ -19,6 +19,15 @@ export interface Repository {
   description: string | null;
   html_url: string;
   private: boolean;
+}
+
+/**
+ * 사용자 설정용 저장 레포 (Firestore users.repositories)
+ * Free 1개, Pro 최대 5개
+ */
+export interface UserRepository {
+  fullName: string;
+  url: string;
 }
 
 /**


### PR DESCRIPTION
### Purpose

단일 레포에서 **다중 레포(Free 1개 / Pro 최대 5개)** 로 전환하고, 플래시카드 화면의 nav/레이아웃·모바일 UX 이슈를 수정합니다.

### Description

- **다중 레포**
  - 타입: 기존 단일 레포 필드 제거, `repositories` 배열만 사용
  - 백엔드: getUserData, getCommits, getFilename, getMarkdown, 플래시카드 생성 로직을 다중 레포 대응으로 수정
  - 앱 API: getCommits, getFilename 등에 `repositoryFullName`(또는 동일 목적 옵션) 전달
  - 설정/온보딩: `repositories`만 저장·표시, Free 1개 / Pro 5개 제한 UI
  - useTodayFlashcards: 다중 레포 데이터 합치기, 카드 메타에 `metadata.repositoryFullName` 포함
  - 카드 UI: 레포명 표시, 덱 셔플 버튼 추가

- **레이아웃·UX**
  - **덱 셔플 클릭 불가**: fixed nav가 클릭을 가로채는 문제 → nav에 `pointer-events-none`, 버튼 래퍼만 `pointer-events-auto`, 플로팅 navbar(`top-4 left-4 right-4`) 및 콘텐츠 상단 패딩 적용
  - **상단 하얀 배경**: 콘텐츠 래퍼에 `bg-bg` 적용
  - **모바일 세로 스크롤**: `h-screen` + 내부 `flex-1 min-h-0 overflow-auto`, FlashCardViewer/PastDateReview 루트를 `min-h-full`로 변경
  - **웹 인디케이터 2개**: 뷰어 인디케이터 span은 모바일에서만 표시(`hidden max-[768px]:inline-flex`), Player는 `renderIndicator`로 모바일에서 기본 인디케이터 비표시
  - **모바일**: 인디케이터+셔플 한 줄, nav 컴팩트화, FlashCardPlayer에 `onSlideChange`/`renderIndicator` prop 추가
  - **모바일 가운데 배치**: 인디케이터·셔플·플래시카드 영역을 한 블록으로 묶어 `justify-center`로 세로 중앙 배치

| 영역 | 변경 파일 예시 |
|------|----------------|
| 타입 | `app/src/types.ts`, `features/flashcard/types.ts` |
| 백엔드 | `functions`: schedule, getUserData, getCommits 등 |
| 설정/온보딩 | Settings.tsx, Onboarding.tsx, App.tsx |
| 플래시카드 | FlashCardViewer.tsx, FlashCardPlayer.tsx, useTodayFlashcards |
| 레이아웃 | App.tsx, FlashCardViewer.tsx, PastDateReview.tsx |

### How to test

1. 로그인 후 설정에서 레포 추가/삭제가 되고, Free 1개·Pro 5개 제한이 적용되는지 확인
2. 플래시카드 화면에서 **덱 셔플** 버튼 클릭 시 덱이 섞이는지 확인
3. 플래시카드 화면에서 **설정(⚙️)** 버튼 클릭 시 설정 페이지로 이동하는지 확인
4. 데스크톱: 인디케이터가 1개만 보이는지, 키보드 안내+셔플이 한 줄에 보이는지 확인
5. 모바일(또는 768px 이하): 인디케이터+셔플이 한 줄로 보이고, 해당 블록과 카드가 세로 가운데 배치되는지 확인
6. 모바일에서 불필요한 세로 스크롤이 없고, 상단에 하얀 띠가 없음을 확인

### Review Requirement

- 다중 레포 시 Firestore/API 호출 경로와 `repositories`/`repositoryFullName` 사용처가 일관되는지
- nav의 `pointer-events` 분리로 인해 다른 fixed/absolute 요소와 겹칠 수 있는지
- 모바일·데스크톱 브레이크포인트(768px) 전환 시 인디케이터·레이아웃이 의도대로 동작하는지

### Additional Info

- **관련 Notion**: [🗂️ 다중 레포](https://www.notion.so/chucoding/30ffd64d44a08046b868d16df3f440a1)
- ui-ux-pro-max 가이드(플로팅 navbar, content padding 등) 반영