### PR TITLE
[TSK-126] Lucide 아이콘 적용 및 이모지·console.log 정리

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.12.2",
     "firebase": "^10.4.0",
     "github-markdown-css": "^5.8.1",
+    "lucide-react": "^0.575.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,7 +14,7 @@ import Onboarding from './pages/Onboarding';
 import Card from './components/Card';
 import { useTodayFlashcards } from './hooks/useTodayFlashcards';
 import { useNavigationStore } from './stores/navigationStore';
-import { BookOpen, ArrowLeft, Settings, Clock } from 'lucide-react';
+import { BookOpen, ArrowLeft, Settings as SettingsIcon, Clock } from 'lucide-react';
 
 const App: React.FC = () => {
   const [user, setUser] = useState<User | null>(null);
@@ -177,7 +177,7 @@ const App: React.FC = () => {
                 className="py-2 px-4 bg-surface/95 text-text border border-border rounded-lg cursor-pointer text-[1.2rem] transition-all duration-200 shadow-[0_2px_8px_rgba(0,0,0,0.3)] backdrop-blur-sm hover:bg-surface-light hover:-translate-y-px hover:shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
                 title="설정"
               >
-                <Settings className="w-5 h-5" aria-hidden />
+                <SettingsIcon className="w-5 h-5" aria-hidden />
               </button>
             </div>
           )}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,7 @@ import Onboarding from './pages/Onboarding';
 import Card from './components/Card';
 import { useTodayFlashcards } from './hooks/useTodayFlashcards';
 import { useNavigationStore } from './stores/navigationStore';
+import { BookOpen, ArrowLeft, Settings, Clock } from 'lucide-react';
 
 const App: React.FC = () => {
   const [user, setUser] = useState<User | null>(null);
@@ -125,9 +126,9 @@ const App: React.FC = () => {
       <>
         <Card>
           <div className="w-[50px] h-[50px] border-[3px] border-white/30 border-t-white rounded-full animate-spin mx-auto mb-5"></div>
-          <h2 className="mb-2.5 text-xl">📚 플래시카드 준비 중</h2>
+          <h2 className="mb-2.5 text-xl flex items-center justify-center gap-2"><BookOpen className="w-6 h-6 shrink-0" aria-hidden />플래시카드 준비 중</h2>
           <p className="text-base">GitHub에서 최근 커밋을 분석하고 있습니다...</p>
-          <p className="mt-2.5 text-[0.9rem] opacity-80">⏱️ 데이터 양에 따라 시간이 조금 걸릴 수 있습니다</p>
+          <p className="mt-2.5 text-[0.9rem] opacity-80 flex items-center justify-center gap-1.5"><Clock className="w-4 h-4 shrink-0" aria-hidden />데이터 양에 따라 시간이 조금 걸릴 수 있습니다</p>
         </Card>
       </>
     );
@@ -163,7 +164,8 @@ const App: React.FC = () => {
                 onClick={currentPage === 'pricing' ? navigateToSettings : navigateToFlashcard}
                 className="py-2 px-4 bg-surface/95 text-text border border-border rounded-lg cursor-pointer font-semibold transition-all duration-200 shadow-[0_2px_8px_rgba(0,0,0,0.3)] flex items-center gap-1.5 backdrop-blur-sm hover:bg-surface-light hover:-translate-y-px hover:shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
               >
-                ← 뒤로가기
+                <ArrowLeft className="w-5 h-5 shrink-0" aria-hidden />
+                뒤로가기
               </button>
             )}
           </div>
@@ -175,7 +177,7 @@ const App: React.FC = () => {
                 className="py-2 px-4 bg-surface/95 text-text border border-border rounded-lg cursor-pointer text-[1.2rem] transition-all duration-200 shadow-[0_2px_8px_rgba(0,0,0,0.3)] backdrop-blur-sm hover:bg-surface-light hover:-translate-y-px hover:shadow-[0_4px_12px_rgba(0,0,0,0.4)]"
                 title="설정"
               >
-                ⚙️
+                <Settings className="w-5 h-5" aria-hidden />
               </button>
             </div>
           )}

--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -5,6 +5,7 @@ import FileContentBlock from '../../templates/FileContentBlock';
 import { getFileContent, getMarkdown } from '../../api/github-api';
 import type { FlashCard } from './types';
 import { trackEvent } from '../../analytics';
+import { Sparkles, Folder } from 'lucide-react';
 
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -22,9 +23,7 @@ function AIAnswerFloatingBlock({ answer }: { answer: string }) {
     >
       <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-200">
         <span className="flex items-center justify-center w-6 h-6 rounded-xl bg-primary/10 text-primary" aria-hidden>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-            <path fillRule="evenodd" d="M9 4.5a.75.75 0 01.721.544l.813 2.846a2.25 2.25 0 001.576 1.576l2.846.813a.75.75 0 010 1.442l-2.846.813a2.25 2.25 0 00-1.576 1.576l-.813 2.846a.75.75 0 01-1.442 0l-.813-2.846a2.25 2.25 0 00-1.576-1.576l-2.846-.813a.75.75 0 010-1.442l2.846-.813A2.25 2.25 0 007.466 7.89l.813-2.846A.75.75 0 019 4.5zM18 1.5a.75.75 0 01.728.568l.258 1.036c.236.94.97 1.674 1.91 1.91l1.036.258a.75.75 0 010 1.456l-1.036.258a2.25 2.25 0 00-1.91 1.91l-.258 1.036a.75.75 0 01-1.456 0l-.258-1.036a2.25 2.25 0 00-1.91-1.91l-1.036-.258a.75.75 0 010-1.456l1.036-.258a2.25 2.25 0 001.91-1.91l.258-1.036A.75.75 0 0118 1.5z" clipRule="evenodd" />
-          </svg>
+          <Sparkles className="w-3.5 h-3.5" aria-hidden />
         </span>
         <span className="text-xs font-semibold uppercase tracking-wider text-slate-500">예시 답변</span>
       </div>
@@ -316,9 +315,7 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                             className="inline-flex items-center gap-1.5 mr-2 px-2 py-1 rounded-lg bg-white border border-slate-200 text-[0.75rem] font-mono text-slate-600 no-underline transition-colors duration-200 hover:bg-slate-100 hover:border-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
                             onClick={(e) => e.stopPropagation()}
                           >
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5 shrink-0" aria-hidden>
-                              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-                            </svg>
+                            <Folder className="w-3.5 h-3.5 shrink-0" aria-hidden />
                             <span className="truncate max-w-[140px] sm:max-w-[200px]" title={card.metadata.repositoryFullName}>{card.metadata.repositoryFullName}</span>
                           </a>
                         )}
@@ -397,9 +394,7 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                     <div className="flex flex-col items-center justify-center w-full p-4 text-center">
                       {card.metadata?.repositoryFullName && (
                         <span className="inline-flex items-center gap-1.5 mb-2 px-2.5 py-1 rounded-lg bg-slate-100 border border-slate-200 text-[0.75rem] font-mono text-slate-600">
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5 shrink-0" aria-hidden>
-                            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-                          </svg>
+                          <Folder className="w-3.5 h-3.5 shrink-0" aria-hidden />
                           <span className="truncate max-w-[200px] sm:max-w-[280px]" title={card.metadata.repositoryFullName}>{card.metadata.repositoryFullName}</span>
                         </span>
                       )}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -13,13 +13,7 @@ if (typeof clarityId === 'string' && clarityId.trim()) {
 // PWA Service Worker 등록
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/firebase-messaging-sw.js')
-      .then((registration) => {
-        console.log('SW registered: ', registration);
-      })
-      .catch((registrationError) => {
-        console.log('SW registration failed: ', registrationError);
-      });
+    navigator.serviceWorker.register('/firebase-messaging-sw.js').catch(() => {});
   });
 }
 

--- a/app/src/pages/FlashCardViewer.tsx
+++ b/app/src/pages/FlashCardViewer.tsx
@@ -19,6 +19,7 @@ import { FlashCardPlayer } from '../features/flashcard';
 import type { FlashCard } from '../features/flashcard';
 import { auth, store } from '../firebase';
 import { getCurrentDate, shuffleArray } from '../modules/utils';
+import { Shuffle } from 'lucide-react';
 
 /**
  * 로그인 사용자 전용 플래시카드 뷰어
@@ -90,15 +91,7 @@ const FlashCardViewer: React.FC = () => {
             aria-label="덱 순서 섞기"
             className={`${shuffleBtnClass} max-[768px]:order-last`}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5 shrink-0" aria-hidden>
-              <path d="M16 3h5v5" />
-              <path d="M8 3H3v5" />
-              <path d="M12 22v-8.3a4 4 0 0 0-1.172-2.872L3 3" />
-              <path d="m15 9 6-6" />
-              <path d="M9 21H4v-5" />
-              <path d="M21 21v-5h-5" />
-              <path d="m15 15 6 6" />
-            </svg>
+            <Shuffle className="w-5 h-5 shrink-0" aria-hidden />
             <span>덱 셔플</span>
           </button>
         </div>

--- a/app/src/pages/LandingDemo.tsx
+++ b/app/src/pages/LandingDemo.tsx
@@ -3,6 +3,7 @@ import { FlashCardPlayer } from '../features/flashcard';
 import type { FlashCard } from '../features/flashcard';
 import { generateDemoFlashcards } from '../lib/demoFlashcards';
 import { trackEvent } from '../analytics';
+import { Github, Info } from 'lucide-react';
 
 /**
  * 랜딩 데모 페이지
@@ -60,13 +61,7 @@ const LandingDemo: React.FC = () => {
     <>
       <form onSubmit={handleSubmit}>
         <div className="flex items-center bg-surface-light/60 backdrop-blur-md rounded-2xl border border-border shadow-[0_16px_48px_rgba(0,0,0,0.3)] overflow-hidden p-1.5 max-[768px]:flex-col max-[768px]:p-3 max-[768px]:gap-2">
-          <svg
-            className="w-5 h-5 ml-4 shrink-0 text-text-muted max-[768px]:hidden"
-            viewBox="0 0 16 16"
-            fill="currentColor"
-          >
-            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-          </svg>
+          <Github className="w-5 h-5 ml-4 shrink-0 text-text-muted max-[768px]:hidden" aria-hidden />
           <input
             type="text"
             className="flex-1 border-0 outline-none text-base py-3.5 px-3 bg-transparent text-text min-w-0 placeholder:text-text-muted max-[768px]:w-full max-[768px]:text-center max-[768px]:py-3"
@@ -133,9 +128,7 @@ const LandingDemo: React.FC = () => {
                   role="note"
                   aria-label="데모 안내"
                 >
-                  <svg className="w-3.5 h-3.5 shrink-0 text-text-muted" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
-                    <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
-                  </svg>
+                  <Info className="w-3.5 h-3.5 shrink-0 text-text-muted" aria-hidden />
                   <span>데모에서는 가장 최근 커밋 3개를 기반으로 플래시카드를 생성합니다</span>
                 </p>
                 <p className="text-text-body text-lg mb-5">

--- a/app/src/pages/Login.tsx
+++ b/app/src/pages/Login.tsx
@@ -30,13 +30,6 @@ const Login: React.FC = () => {
           const deletedAt = new Date(deletedData.deletedAt);
           const deletedDateStr = deletedAt.toLocaleDateString('en-CA');
           
-          console.log('탈퇴 기록 발견:', {
-            deletedAt: deletedData.deletedAt,
-            deletedDateStr,
-            todayStr,
-            email: deletedData.email
-          });
-          
           if (deletedDateStr === todayStr) {
             await signOut(auth);
             setError('회원탈퇴 후에는 다음날부터 재가입할 수 있습니다.');

--- a/app/src/pages/Login.tsx
+++ b/app/src/pages/Login.tsx
@@ -30,7 +30,7 @@ const Login: React.FC = () => {
           const deletedAt = new Date(deletedData.deletedAt);
           const deletedDateStr = deletedAt.toLocaleDateString('en-CA');
           
-          console.log('⚠️ 탈퇴 기록 발견:', {
+          console.log('탈퇴 기록 발견:', {
             deletedAt: deletedData.deletedAt,
             deletedDateStr,
             todayStr,
@@ -47,7 +47,7 @@ const Login: React.FC = () => {
           }
         }
       } catch (firestoreError) {
-        console.error('❌ Firestore 탈퇴 기록 확인 실패:', firestoreError);
+        console.error('Firestore 탈퇴 기록 확인 실패:', firestoreError);
         // Firestore 오류가 있어도 로그인은 계속 진행
         // 보안상 문제가 있을 수 있으므로 관리자에게 알림 필요
       }

--- a/app/src/pages/NoDataView.tsx
+++ b/app/src/pages/NoDataView.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { useNavigationStore } from '../stores/navigationStore';
 import Card from '../components/Card';
+import { ClipboardList, Settings } from 'lucide-react';
 
 const NoDataView: React.FC = () => {
   const { navigateToSettings } = useNavigationStore();
   return (
     <Card>
       <div className="w-20 h-20 mx-auto mb-6 rounded-2xl bg-surface-light border border-border flex items-center justify-center" aria-hidden>
-        <svg className="w-10 h-10 text-text-muted" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
-        </svg>
+        <ClipboardList className="w-10 h-10 text-text-muted" aria-hidden />
       </div>
       <h2 className="text-xl mb-2 font-semibold text-text leading-tight">
         플래시카드가 없습니다
@@ -25,9 +24,7 @@ const NoDataView: React.FC = () => {
         onClick={() => navigateToSettings()}
         className="inline-flex items-center justify-center gap-2 py-3 px-6 bg-primary text-bg border-none rounded-xl text-sm font-semibold cursor-pointer transition-all duration-200 hover:bg-primary-dark hover:-translate-y-px hover:shadow-[0_6px_20px_rgba(7,166,107,0.3)]"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75" />
-        </svg>
+        <Settings className="w-4 h-4" aria-hidden />
         설정으로 이동
       </button>
     </Card>

--- a/app/src/pages/Onboarding.tsx
+++ b/app/src/pages/Onboarding.tsx
@@ -4,6 +4,7 @@ import { auth, store } from '../firebase';
 import { trackEvent } from '../analytics';
 import { getRepositories } from '../api/github-api';
 import { Repository, UserRepository } from '../types';
+import { LayoutTemplate, TriangleAlert, CircleCheck, RefreshCw, Lightbulb, Smartphone, ChevronRight, ChevronDown } from 'lucide-react';
 
 interface OnboardingProps {
   onComplete: () => void;
@@ -155,15 +156,15 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
             
             <div className="my-8 text-left space-y-3">
               <div className="flex items-center gap-3 p-4 bg-surface-light rounded-xl transition-colors duration-200 hover:bg-border cursor-default border border-transparent hover:border-border-medium">
-                <span className="text-2xl shrink-0" aria-hidden>🔄</span>
+                <span className="shrink-0 flex items-center justify-center text-primary" aria-hidden><RefreshCw className="w-6 h-6" /></span>
                 <span className="text-sm text-text-body font-medium max-[640px]:text-[13px]">1일, 7일, 30일 전 커밋 자동 분석</span>
               </div>
               <div className="flex items-center gap-3 p-4 bg-surface-light rounded-xl transition-colors duration-200 hover:bg-border cursor-default border border-transparent hover:border-border-medium">
-                <span className="text-2xl shrink-0" aria-hidden>💡</span>
+                <span className="shrink-0 flex items-center justify-center text-primary" aria-hidden><Lightbulb className="w-6 h-6" /></span>
                 <span className="text-sm text-text-body font-medium max-[640px]:text-[13px]">AI가 핵심 내용을 질문으로 변환</span>
               </div>
               <div className="flex items-center gap-3 p-4 bg-surface-light rounded-xl transition-colors duration-200 hover:bg-border cursor-default border border-transparent hover:border-border-medium">
-                <span className="text-2xl shrink-0" aria-hidden>📱</span>
+                <span className="shrink-0 flex items-center justify-center text-primary" aria-hidden><Smartphone className="w-6 h-6" /></span>
                 <span className="text-sm text-text-body font-medium max-[640px]:text-[13px]">매일 아침 푸시 알림으로 복습</span>
               </div>
             </div>
@@ -172,7 +173,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
               className="w-full py-3.5 px-8 border-none rounded-xl text-base font-semibold cursor-pointer transition-all duration-300 bg-primary text-bg shadow-[0_4px_15px_rgba(7,166,107,0.3)] mb-3 hover:enabled:-translate-y-0.5 hover:enabled:bg-primary-dark hover:enabled:shadow-[0_6px_20px_rgba(7,166,107,0.4)] disabled:opacity-60 disabled:cursor-not-allowed disabled:transform-none"
               onClick={handleNext}
             >
-              시작하기 →
+              <span className="inline-flex items-center justify-center gap-1.5">시작하기 <ChevronRight className="w-5 h-5 shrink-0" aria-hidden /></span>
             </button>
           </div>
         )}
@@ -181,7 +182,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
         {step === 2 && (
           <div className="text-center animate-fade-in">
             <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/10 flex items-center justify-center" aria-hidden>
-              <svg className="w-8 h-8 text-primary" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75"/></svg>
+              <LayoutTemplate className="w-8 h-8 text-primary" aria-hidden />
             </div>
             <h1 className="text-3xl font-bold text-text mb-4 m-0 max-[640px]:text-[28px]">리포지토리 선택</h1>
             <p className="text-base text-text-light leading-relaxed mb-8 m-0 max-[640px]:text-sm">
@@ -192,7 +193,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
             {error && (
               <div className="bg-error-bg border-2 border-error-light rounded-xl p-4 mb-6 flex gap-3 items-start animate-[errorSlide_0.3s_ease-out]">
                 <span className="shrink-0 w-8 h-8 text-error flex items-center justify-center" aria-hidden>
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/></svg>
+                  <TriangleAlert className="w-5 h-5" aria-hidden />
                 </span>
                 <div className="flex-1">
                   <p className="text-error-text text-sm leading-relaxed mb-4 font-medium m-0">{error.message}</p>
@@ -224,7 +225,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
                     <span className={selectedRepo ? "" : "text-text-muted"}>
                       {selectedRepo ? selectedRepo.fullName : "리포지토리를 선택하세요"}
                     </span>
-                    <span className="text-xs text-text-light transition-transform duration-200">▼</span>
+                    <ChevronDown className="w-4 h-4 text-text-light shrink-0 transition-transform duration-200" aria-hidden />
                   </button>
                   
                   {isDropdownOpen && (
@@ -258,7 +259,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
               onClick={handleNext}
               disabled={!canProceed() || saving}
             >
-              {saving ? '저장 중...' : '완료하기 →'}
+              {saving ? '저장 중...' : (<span className="inline-flex items-center justify-center gap-1.5">완료하기 <ChevronRight className="w-5 h-5 shrink-0" aria-hidden /></span>)}
             </button>
 
             <button 
@@ -275,7 +276,7 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
         {step === 3 && (
           <div className="text-center animate-fade-in">
             <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/10 flex items-center justify-center animate-[successPulse_0.6s_ease-out]" aria-hidden>
-              <svg className="w-8 h-8 text-primary" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+              <CircleCheck className="w-8 h-8 text-primary" aria-hidden />
             </div>
             <h1 className="text-3xl font-bold text-text mb-4 m-0 max-[640px]:text-[28px]">준비 완료</h1>
             <p className="text-base text-text-light leading-relaxed mb-8 m-0 max-[640px]:text-sm">

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -222,8 +222,7 @@ const Settings: React.FC = () => {
         const flashcardsSnapshot = await getDocs(flashcardsRef);
         const deletePromises = flashcardsSnapshot.docs.map(d => deleteDoc(d.ref));
         await Promise.all(deletePromises);
-        console.log('Firestore 플래시카드 데이터를 삭제했습니다.');
-        
+
         setMessage({ type: 'success', text: '설정이 저장되었습니다. 새로운 데이터를 불러옵니다...' });
         
         // 페이지 새로고침으로 플래시카드 새로 생성
@@ -340,40 +339,24 @@ const Settings: React.FC = () => {
       setDeleting(true);
       setMessage(null);
 
-      console.log('회원탈퇴 시작:', {
-        uid: user.uid,
-        email: user.email,
-        displayName: user.displayName
-      });
-
       // 1. 탈퇴 기록 생성 (재가입 방지용)
-      console.log('탈퇴 기록 생성 중...');
       await setDoc(doc(store, 'deletedUsers', user.uid), {
         deletedAt: new Date().toISOString(),
         email: user.email,
         githubUsername: user.displayName,
       });
-      console.log('탈퇴 기록 생성 완료');
-      
+
       // 2. Firestore 플래시카드 서브컬렉션 삭제 (Auth 삭제 전에 처리해야 함)
-      console.log('Firestore 플래시카드 데이터 삭제 중...');
       const flashcardsRef = collection(store, 'users', user.uid, 'flashcards');
       const flashcardsSnapshot = await getDocs(flashcardsRef);
       const deletePromises = flashcardsSnapshot.docs.map(d => deleteDoc(d.ref));
       await Promise.all(deletePromises);
-      console.log('Firestore 플래시카드 데이터 삭제 완료');
 
       // 3. Firestore 사용자 데이터 삭제
-      console.log('Firestore 사용자 데이터 삭제 중...');
       await deleteDoc(doc(store, 'users', user.uid));
-      console.log('Firestore 사용자 데이터 삭제 완료');
 
       // 4. Firebase Auth 계정 삭제 (항상 마지막 — 이후 인증 불가)
-      console.log('Firebase Auth 계정 삭제 중...');
       await user.delete();
-      console.log('Firebase Auth 계정 삭제 완료');
-      
-      console.log('회원탈퇴 완료');
     } catch (error: any) {
       console.error('회원탈퇴 실패:', error);
       
@@ -386,46 +369,34 @@ const Settings: React.FC = () => {
       if (needsReauth) {
         try {
           // 자동으로 재인증 시도
-          console.log('재인증이 필요합니다. GitHub 로그인 팝업을 엽니다...');
           setMessage({ 
             type: 'error', 
             text: '보안을 위해 재인증이 필요합니다. 팝업에서 GitHub 로그인을 진행해주세요.' 
           });
           
           await reauthenticateWithPopup(user, githubProvider);
-          console.log('재인증 완료');
-          
+
           // 재인증 후 다시 계정 삭제 시도
           setMessage({ type: 'error', text: '재인증되었습니다. 다시 탈퇴를 시도합니다...' });
           
           // 1. 탈퇴 기록 생성
-          console.log('(재시도) 탈퇴 기록 생성 중...');
           await setDoc(doc(store, 'deletedUsers', user.uid), {
             deletedAt: new Date().toISOString(),
             email: user.email,
             githubUsername: user.displayName,
           });
-          console.log('(재시도) 탈퇴 기록 생성 완료');
-          
+
           // 2. Firestore 플래시카드 서브컬렉션 삭제 (Auth 삭제 전에 처리해야 함)
-          console.log('(재시도) Firestore 플래시카드 데이터 삭제 중...');
           const flashcardsRef = collection(store, 'users', user.uid, 'flashcards');
           const flashcardsSnapshot = await getDocs(flashcardsRef);
           const deletePromises = flashcardsSnapshot.docs.map(d => deleteDoc(d.ref));
           await Promise.all(deletePromises);
-          console.log('(재시도) Firestore 플래시카드 데이터 삭제 완료');
 
           // 3. Firestore 사용자 데이터 삭제
-          console.log('(재시도) Firestore 사용자 데이터 삭제 중...');
           await deleteDoc(doc(store, 'users', user.uid));
-          console.log('(재시도) Firestore 사용자 데이터 삭제 완료');
 
           // 4. Firebase Auth 계정 삭제 (항상 마지막 — 이후 인증 불가)
-          console.log('(재시도) Firebase Auth 계정 삭제 중...');
           await user.delete();
-          console.log('(재시도) Firebase Auth 계정 삭제 완료');
-          
-          console.log('(재시도) 회원탈퇴 완료');
         } catch (reauthError: any) {
           console.error('재인증 실패:', reauthError);
           

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import { Repository, UserRepository } from '../types';
 import { useSubscription } from '../hooks/useSubscription';
 import { useNavigationStore } from '../stores/navigationStore';
 import { getCurrentDate } from '../modules/utils';
+import { X, Bell, Megaphone, ChevronUp, ChevronDown, Info, Lock, Globe, FileText, ClipboardList, User, LogOut, UserX, Sparkles, Lightbulb } from 'lucide-react';
 
 const MAX_REPOS_FREE = 1;
 const MAX_REPOS_PRO = 5;
@@ -85,7 +86,7 @@ const Settings: React.FC = () => {
         setNoticeMessage(trimmed || null);
       },
       (error) => {
-        console.error('❌ 공지사항 가져오기 실패:', error);
+        console.error('공지사항 가져오기 실패:', error);
       }
     );
     return () => unsubscribe();
@@ -99,7 +100,7 @@ const Settings: React.FC = () => {
       const repos = await getRepositories();
       setRepositories(repos);
     } catch (error) {
-      console.error('❌ 리포지토리 불러오기 실패:', error);
+      console.error('리포지토리 불러오기 실패:', error);
       setReposFetchError(true);
       setMessage({ type: 'error', text: '리포지토리 목록을 불러오는데 실패했습니다.' });
     } finally {
@@ -221,16 +222,16 @@ const Settings: React.FC = () => {
         const flashcardsSnapshot = await getDocs(flashcardsRef);
         const deletePromises = flashcardsSnapshot.docs.map(d => deleteDoc(d.ref));
         await Promise.all(deletePromises);
-        console.log('🗑️ Firestore 플래시카드 데이터를 삭제했습니다.');
+        console.log('Firestore 플래시카드 데이터를 삭제했습니다.');
         
-        setMessage({ type: 'success', text: '✅ 설정이 저장되었습니다. 새로운 데이터를 불러옵니다...' });
+        setMessage({ type: 'success', text: '설정이 저장되었습니다. 새로운 데이터를 불러옵니다...' });
         
         // 페이지 새로고침으로 플래시카드 새로 생성
         setTimeout(() => {
           window.location.reload();
         }, 500);
       } catch (clearError) {
-        console.error('❌ 플래시카드 데이터 삭제 실패:', clearError);
+        console.error('플래시카드 데이터 삭제 실패:', clearError);
         setMessage({ type: 'error', text: '데이터 삭제에 실패했습니다. 다시 시도해주세요.' });
         setSaving(false);
       }
@@ -339,42 +340,42 @@ const Settings: React.FC = () => {
       setDeleting(true);
       setMessage(null);
 
-      console.log('🚨 회원탈퇴 시작:', {
+      console.log('회원탈퇴 시작:', {
         uid: user.uid,
         email: user.email,
         displayName: user.displayName
       });
 
       // 1. 탈퇴 기록 생성 (재가입 방지용)
-      console.log('📝 탈퇴 기록 생성 중...');
+      console.log('탈퇴 기록 생성 중...');
       await setDoc(doc(store, 'deletedUsers', user.uid), {
         deletedAt: new Date().toISOString(),
         email: user.email,
         githubUsername: user.displayName,
       });
-      console.log('✅ 탈퇴 기록 생성 완료');
+      console.log('탈퇴 기록 생성 완료');
       
       // 2. Firestore 플래시카드 서브컬렉션 삭제 (Auth 삭제 전에 처리해야 함)
-      console.log('🗑️ Firestore 플래시카드 데이터 삭제 중...');
+      console.log('Firestore 플래시카드 데이터 삭제 중...');
       const flashcardsRef = collection(store, 'users', user.uid, 'flashcards');
       const flashcardsSnapshot = await getDocs(flashcardsRef);
       const deletePromises = flashcardsSnapshot.docs.map(d => deleteDoc(d.ref));
       await Promise.all(deletePromises);
-      console.log('✅ Firestore 플래시카드 데이터 삭제 완료');
+      console.log('Firestore 플래시카드 데이터 삭제 완료');
 
       // 3. Firestore 사용자 데이터 삭제
-      console.log('🗑️ Firestore 사용자 데이터 삭제 중...');
+      console.log('Firestore 사용자 데이터 삭제 중...');
       await deleteDoc(doc(store, 'users', user.uid));
-      console.log('✅ Firestore 사용자 데이터 삭제 완료');
+      console.log('Firestore 사용자 데이터 삭제 완료');
 
       // 4. Firebase Auth 계정 삭제 (항상 마지막 — 이후 인증 불가)
-      console.log('🗑️ Firebase Auth 계정 삭제 중...');
+      console.log('Firebase Auth 계정 삭제 중...');
       await user.delete();
-      console.log('✅ Firebase Auth 계정 삭제 완료');
+      console.log('Firebase Auth 계정 삭제 완료');
       
-      console.log('🎉 회원탈퇴 완료');
+      console.log('회원탈퇴 완료');
     } catch (error: any) {
-      console.error('❌ 회원탈퇴 실패:', error);
+      console.error('회원탈퇴 실패:', error);
       
       // 재인증이 필요한 경우 (다양한 오류 코드 처리)
       const needsReauth = 
@@ -385,46 +386,46 @@ const Settings: React.FC = () => {
       if (needsReauth) {
         try {
           // 자동으로 재인증 시도
-          console.log('🔄 재인증이 필요합니다. GitHub 로그인 팝업을 엽니다...');
+          console.log('재인증이 필요합니다. GitHub 로그인 팝업을 엽니다...');
           setMessage({ 
             type: 'error', 
             text: '보안을 위해 재인증이 필요합니다. 팝업에서 GitHub 로그인을 진행해주세요.' 
           });
           
           await reauthenticateWithPopup(user, githubProvider);
-          console.log('✅ 재인증 완료');
+          console.log('재인증 완료');
           
           // 재인증 후 다시 계정 삭제 시도
           setMessage({ type: 'error', text: '재인증되었습니다. 다시 탈퇴를 시도합니다...' });
           
           // 1. 탈퇴 기록 생성
-          console.log('📝 (재시도) 탈퇴 기록 생성 중...');
+          console.log('(재시도) 탈퇴 기록 생성 중...');
           await setDoc(doc(store, 'deletedUsers', user.uid), {
             deletedAt: new Date().toISOString(),
             email: user.email,
             githubUsername: user.displayName,
           });
-          console.log('✅ (재시도) 탈퇴 기록 생성 완료');
+          console.log('(재시도) 탈퇴 기록 생성 완료');
           
           // 2. Firestore 플래시카드 서브컬렉션 삭제 (Auth 삭제 전에 처리해야 함)
-          console.log('🗑️ (재시도) Firestore 플래시카드 데이터 삭제 중...');
+          console.log('(재시도) Firestore 플래시카드 데이터 삭제 중...');
           const flashcardsRef = collection(store, 'users', user.uid, 'flashcards');
           const flashcardsSnapshot = await getDocs(flashcardsRef);
           const deletePromises = flashcardsSnapshot.docs.map(d => deleteDoc(d.ref));
           await Promise.all(deletePromises);
-          console.log('✅ (재시도) Firestore 플래시카드 데이터 삭제 완료');
+          console.log('(재시도) Firestore 플래시카드 데이터 삭제 완료');
 
           // 3. Firestore 사용자 데이터 삭제
-          console.log('🗑️ (재시도) Firestore 사용자 데이터 삭제 중...');
+          console.log('(재시도) Firestore 사용자 데이터 삭제 중...');
           await deleteDoc(doc(store, 'users', user.uid));
-          console.log('✅ (재시도) Firestore 사용자 데이터 삭제 완료');
+          console.log('(재시도) Firestore 사용자 데이터 삭제 완료');
 
           // 4. Firebase Auth 계정 삭제 (항상 마지막 — 이후 인증 불가)
-          console.log('🗑️ (재시도) Firebase Auth 계정 삭제 중...');
+          console.log('(재시도) Firebase Auth 계정 삭제 중...');
           await user.delete();
-          console.log('✅ (재시도) Firebase Auth 계정 삭제 완료');
+          console.log('(재시도) Firebase Auth 계정 삭제 완료');
           
-          console.log('🎉 (재시도) 회원탈퇴 완료');
+          console.log('(재시도) 회원탈퇴 완료');
         } catch (reauthError: any) {
           console.error('재인증 실패:', reauthError);
           
@@ -465,7 +466,7 @@ const Settings: React.FC = () => {
         {/* 공지사항: config/notice 문서의 message가 있을 때만 표시 */}
         {noticeMessage && (
           <div className="flex items-start gap-3 bg-[#f59e0b]/10 border-2 border-[#f59e0b]/40 rounded-xl p-4 mb-8 animate-fade-in max-[768px]:p-3 max-[768px]:mb-6">
-            <div className="text-2xl shrink-0 max-[768px]:text-xl">📢</div>
+            <Megaphone className="w-7 h-7 shrink-0 max-[768px]:w-6 max-[768px]:h-6 text-[#f59e0b]" aria-hidden />
             <p className="m-0 flex-1 text-[#fbbf24] text-[0.9rem] leading-relaxed font-medium max-[768px]:text-[0.85rem]">
               {noticeMessage}
             </p>
@@ -562,9 +563,7 @@ const Settings: React.FC = () => {
                               className="shrink-0 p-2 rounded-lg border border-border text-text-body cursor-pointer transition-colors duration-200 hover:bg-error/10 hover:border-error hover:text-error focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
                               onClick={() => handleRemoveRepository(r.fullName)}
                             >
-                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
-                                <path d="M18 6L6 18M6 6l12 12" />
-                              </svg>
+                              <X className="w-5 h-5" aria-hidden />
                             </button>
                           )}
                           {tier === 'free' && repoMeta && (
@@ -597,7 +596,7 @@ const Settings: React.FC = () => {
                         {selectedRepos.length ? selectedRepos[0].fullName : '리포지토리를 선택하세요'}
                       </span>
                     )}
-                    <span className="text-text-light text-[0.75rem]">{isDropdownOpen ? '▲' : '▼'}</span>
+                    {isDropdownOpen ? <ChevronUp className="w-4 h-4 text-text-light shrink-0" aria-hidden /> : <ChevronDown className="w-4 h-4 text-text-light shrink-0" aria-hidden />}
                   </button>
 
                   {isDropdownOpen && !saving && (
@@ -631,10 +630,7 @@ const Settings: React.FC = () => {
           <div className="flex flex-col gap-2">
             <h2 className="m-0 text-text-body text-base font-semibold max-[768px]:text-[0.95rem] flex items-center gap-2">
               <span className="inline-flex shrink-0" aria-hidden="true">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5 text-text-light">
-                  <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-                  <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
-                </svg>
+                <Bell className="w-5 h-5 text-text-light" aria-hidden />
               </span>
               알림
             </h2>
@@ -782,16 +778,17 @@ const Settings: React.FC = () => {
             </button>
           )}
         </div>
-        <p className="m-0 mb-2 text-[0.85rem] text-text-light text-left leading-relaxed">
-          ℹ️ GitHub OAuth로 로그인하여 접근 가능한 모든 리포지토리가 표시됩니다.
+        <p className="m-0 mb-2 text-[0.85rem] text-text-light text-left leading-relaxed flex items-center gap-2">
+          <Info className="w-4 h-4 shrink-0" aria-hidden />
+          GitHub OAuth로 로그인하여 접근 가능한 모든 리포지토리가 표시됩니다.
         </p>
-        <p className="m-0 text-[0.85rem] text-text-light text-left leading-relaxed">
-          🔒 = Private 리포지토리, 🌐 = Public 리포지토리
+        <p className="m-0 text-[0.85rem] text-text-light text-left leading-relaxed flex items-center gap-2 flex-wrap">
+          <span className="inline-flex items-center gap-1"><Lock className="w-4 h-4 shrink-0" aria-hidden /> = Private 리포지토리</span>, <span className="inline-flex items-center gap-1"><Globe className="w-4 h-4 shrink-0" aria-hidden /> = Public 리포지토리</span>
         </p>
 
         {/* 릴리즈 노트 */}
         <div className="border-t border-border text-left mt-8 pt-5 max-[768px]:pt-4">
-          <h2 className="m-0 mb-2 text-text-body text-base font-semibold max-[768px]:text-[0.95rem]">📝 릴리즈 노트</h2>
+          <h2 className="m-0 mb-2 text-text-body text-base font-semibold max-[768px]:text-[0.95rem] flex items-center gap-2"><FileText className="w-5 h-5 shrink-0" aria-hidden />릴리즈 노트</h2>
           <p className="m-0 mb-4 text-text-light text-[0.9rem] leading-relaxed max-[768px]:text-[0.85rem]">
             새로운 기능과 개선사항을 확인하세요
           </p>
@@ -801,13 +798,14 @@ const Settings: React.FC = () => {
             rel="noopener noreferrer"
             className="inline-block px-6 py-3 bg-primary text-bg border-none rounded-lg text-[0.95rem] font-semibold cursor-pointer transition-all duration-200 no-underline shadow-[0_4px_12px_rgba(7,166,107,0.3)] hover:-translate-y-0.5 hover:bg-primary-dark hover:shadow-[0_6px_16px_rgba(7,166,107,0.4)] max-[768px]:text-[0.9rem] max-[768px]:px-5 max-[768px]:py-2.5"
           >
-            📋 릴리즈 노트 보기
+            <ClipboardList className="w-5 h-5 shrink-0 inline-block align-middle mr-1.5" aria-hidden />
+            릴리즈 노트 보기
           </a>
         </div>
 
         {/* 계정 관리 */}
         <div className="border-t border-border text-left mt-4 pt-5 max-[768px]:pt-4">
-          <h2 className="m-0 mb-2 text-text-body text-base font-semibold max-[768px]:text-[0.95rem]">👤 계정 관리</h2>
+          <h2 className="m-0 mb-2 text-text-body text-base font-semibold max-[768px]:text-[0.95rem] flex items-center gap-2"><User className="w-5 h-5 shrink-0" aria-hidden />계정 관리</h2>
           <p className="m-0 mb-4 text-text-light text-[0.9rem] leading-relaxed max-[768px]:text-[0.85rem]">
             계정 로그아웃 또는 서비스 탈퇴를 진행할 수 있습니다.
           </p>
@@ -817,7 +815,8 @@ const Settings: React.FC = () => {
               className="flex-1 py-3 px-6 bg-primary text-bg border-none rounded-lg text-[0.95rem] font-semibold cursor-pointer transition-all duration-200 shadow-[0_4px_12px_rgba(7,166,107,0.3)] hover:-translate-y-0.5 hover:bg-primary-dark hover:shadow-[0_6px_16px_rgba(7,166,107,0.4)] max-[768px]:w-full"
               onClick={handleLogout}
             >
-              🚪 로그아웃
+              <LogOut className="w-5 h-5 shrink-0 inline-block align-middle mr-1.5" aria-hidden />
+              로그아웃
             </button>
             <button
               type="button"
@@ -841,16 +840,16 @@ const Settings: React.FC = () => {
       {showDeleteDialog && (
         <div className="fixed inset-0 bg-black/60 flex justify-center items-center z-[9999] animate-fade-in p-5" onClick={() => !deleting && setShowDeleteDialog(false)}>
           <div className="bg-surface rounded-2xl p-8 max-w-[500px] w-full shadow-[0_20px_60px_rgba(0,0,0,0.5)] animate-slide-up max-h-[90vh] overflow-y-auto max-[768px]:p-6" onClick={(e) => e.stopPropagation()}>
-            <h2 className="m-0 mb-4 text-text text-2xl font-bold max-[768px]:text-xl">👋 서비스 탈퇴</h2>
+            <h2 className="m-0 mb-4 text-text text-2xl font-bold max-[768px]:text-xl flex items-center gap-2"><UserX className="w-7 h-7 shrink-0" aria-hidden />서비스 탈퇴</h2>
             <p className="m-0 mb-5 text-text-body text-base leading-relaxed">
               정말 탈퇴하시겠어요? 걱정하지 마세요, 언제든 다시 돌아올 수 있습니다.
             </p>
             <div className="m-0 mb-6 p-4 bg-surface-light border border-border rounded-lg">
-              <p className="m-0 mb-3 text-text text-[0.95rem] font-semibold">✨ 탈퇴 시 안내사항</p>
+              <p className="m-0 mb-3 text-text text-[0.95rem] font-semibold flex items-center gap-2"><Sparkles className="w-5 h-5 shrink-0" aria-hidden />탈퇴 시 안내사항</p>
               <ul className="m-0 pl-5 text-text-light">
                 <li className="my-2 leading-relaxed text-[0.9rem]">저장된 모든 데이터가 삭제됩니다</li>
                 <li className="my-2 leading-relaxed text-[0.9rem]">탈퇴 시 다음날부터 재가입할 수 있습니다</li>
-                <li className="my-2 leading-relaxed text-[0.9rem] text-primary font-medium mt-3 pt-3 border-t border-dashed border-border">💡 보안을 위해 GitHub 재인증 팝업이 표시될 수 있습니다</li>
+                <li className="my-2 leading-relaxed text-[0.9rem] text-primary font-medium mt-3 pt-3 border-t border-dashed border-border flex items-center gap-2"><Lightbulb className="w-4 h-4 shrink-0" aria-hidden />보안을 위해 GitHub 재인증 팝업이 표시될 수 있습니다</li>
               </ul>
             </div>
             

--- a/app/src/templates/CodeDiffBlock.tsx
+++ b/app/src/templates/CodeDiffBlock.tsx
@@ -4,6 +4,7 @@ import remarkGfm from 'remark-gfm';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { github } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { highlightText } from '../modules/highlightText';
+import { FileText } from 'lucide-react';
 import 'github-markdown-css/github-markdown.css';
 
 const MONO_STYLE: React.CSSProperties = {
@@ -94,8 +95,9 @@ const CodeDiffBlock: React.FC<CodeDiffBlockProps> = ({ diffContent, highlightStr
             </h2>
           ),
           h3: ({ children }) => (
-            <h3 className="text-[1.25em] font-semibold mt-5 mb-3 text-[#24292f]">
-              📄 {children}
+            <h3 className="text-[1.25em] font-semibold mt-5 mb-3 text-[#24292f] flex items-center gap-2">
+              <FileText className="w-5 h-5 shrink-0" aria-hidden />
+              {children}
             </h3>
           ),
           strong: ({ children }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       github-markdown-css:
         specifier: ^5.8.1
         version: 5.8.1
+      lucide-react:
+        specifier: ^0.575.0
+        version: 0.575.0(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -3549,6 +3552,11 @@ packages:
 
   lru-memoizer@2.3.0:
     resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
+
+  lucide-react@0.575.0:
+    resolution: {integrity: sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
@@ -9105,6 +9113,10 @@ snapshots:
     dependencies:
       lodash.clonedeep: 4.5.0
       lru-cache: 6.0.0
+
+  lucide-react@0.575.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   magic-string@0.25.9:
     dependencies:


### PR DESCRIPTION
### Purpose

app에 **Lucide React** 아이콘을 도입하고, 인라인 SVG·UI 이모지를 Lucide 아이콘으로 통일한 뒤, 의미 없는 **console.log**를 제거합니다. (ui-ux-pro-max 스킬 권장 반영)

### Description

**1. Lucide 아이콘 패키지 적용 및 SVG → Lucide 전환**
- `app`에 `lucide-react` 의존성 추가 (pnpm).
- 다음 6개 파일에서 인라인 SVG를 Lucide 컴포넌트로 교체:
  - **Settings.tsx**: X(레포 제거), Bell(알림 헤더)
  - **Onboarding.tsx**: LayoutTemplate, TriangleAlert, CircleCheck
  - **FlashCardPlayer.tsx**: Sparkles, Folder(2곳)
  - **FlashCardViewer.tsx**: Shuffle
  - **LandingDemo.tsx**: Github, Info
  - **NoDataView.tsx**: ClipboardList, Settings
- 기존 `className`(크기·색상), `aria-hidden` 등 접근성 속성 유지.
- `public/`의 `github-mark.svg`, `github-mark-white.svg`는 로그인/브랜딩용으로 유지.

**2. 이모지 → Lucide 아이콘 전환**
- **Onboarding.tsx**: 🔄💡📱 → RefreshCw, Lightbulb, Smartphone / 시작·완료 버튼 → ChevronRight / ▼ → ChevronDown
- **CodeDiffBlock.tsx**: h3 앞 📄 → FileText
- **Settings.tsx**: 📢▲▼ℹ️🔒🌐📝📋👤🚪👋✨💡 → Megaphone, ChevronUp/Down, Info, Lock, Globe, FileText, ClipboardList, User, LogOut, UserX, Sparkles, Lightbulb
- **App.tsx**: 📚⏱️←⚙️ → BookOpen, Clock, ArrowLeft, SettingsIcon(별칭). 설정 페이지 컴포넌트와 구분 위해 아이콘만 `Settings as SettingsIcon` 사용.
- 콘솔/토스트 메시지 내 이모지 제거(저장 성공 문구 등).

**3. 의미 없는 console.log 제거**
- **main.tsx**: SW 등록 성공/실패 시 `console.log` 2곳 제거. 실패 시 `.catch(() => {})` 유지.
- **Login.tsx**: 탈퇴 기록 발견 시 디버깅용 `console.log` 1곳 제거.
- **Settings.tsx**: 설정 저장 후 플래시카드 삭제 완료 로그 1곳, 회원탈퇴 플로우 진행 로그 18곳 제거.
- **console.error**는 에러 추적용으로 유지(axios, App, Login, Onboarding, Settings, useSubscription, useTodayFlashcards).

### How to test

1. `app` 디렉터리에서 `pnpm install` 후 `pnpm run build` 로 빌드가 성공하는지 확인.
2. `pnpm run dev` 로 앱 실행 후 다음 화면에서 아이콘·문구가 기대대로 보이는지 확인:
   - **온보딩**: Step1(🔄💡📱 → 아이콘), Step2(리포 선택 드롭다운 ▼ → ChevronDown), Step3(완료 체크), 시작하기/완료하기 버튼(화살표 아이콘).
   - **설정**: 공지(📢 → Megaphone), 레포 드롭다운(▲▼), 알림(Bell), OAuth 안내(ℹ️), Private/Public(🔒/🌐), 릴리즈 노트·계정 관리·로그아웃·서비스 탈퇴 다이얼로그(해당 아이콘들).
   - **플래시카드 뷰어**: 덱 셔플 버튼(Shuffle), 카드 내 리포 뱃지(Folder), 예시 답변(Sparkles).
   - **랜딩 데모**: 폼 왼쪽 GitHub 아이콘, 데모 안내(Info).
   - **데이터 없음**: 빈 상태(ClipboardList), 설정으로 이동(Settings).
   - **로딩/네비**: 플래시카드 준비 중(BookOpen), 시간 안내(Clock), 뒤로가기(ArrowLeft), 설정 버튼(Settings 아이콘).
3. 브라우저 개발자 도구 콘솔에서 불필요한 `console.log`가 더 이상 출력되지 않는지 확인(에러 시 `console.error`는 유지).

### Review Requirement

- **Settings.tsx**: Lucide import가 많아졌으므로, 사용처와 이름이 일치하는지 한 번씩만 확인해 주시면 좋습니다.
- **App.tsx**: `Settings` 페이지 컴포넌트와 `SettingsIcon`(Lucide) 구분이 유지되는지 확인 부탁드립니다.
- **접근성**: 기존 `aria-hidden`/`aria-label`이 아이콘·버튼에 그대로 유지되었는지 한 번만 훑어봐 주세요.

### Additional Info

- **관련 Notion**: [아이콘 라이브러리 추가 – 작업 정리](https://www.notion.so/chucoding/310fd64d44a0804ca9a5d73d04e5afe4)
- 변경 파일: Settings, Onboarding, FlashCardPlayer, FlashCardViewer, LandingDemo, NoDataView, CodeDiffBlock, App, main, Login (위 Description 참고).
- 추가 패키지: `lucide-react` (app만).