### PR TITLE
[TSK-127] 카드 UI 내 텍스트 깨짐 현상 수정

### DIFF
--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -226,15 +226,18 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
         .fc-card::-webkit-scrollbar-thumb { background: rgba(34, 197, 94, 0.28); border-radius: 10px; }
         .fc-card::-webkit-scrollbar-thumb:hover { background: rgba(34, 197, 94, 0.45); }
         .fc-card.flipped .markdown-body {
-          width: 100%; height: 100%; overflow-y: auto;
-          padding: 2rem; box-sizing: border-box;
+          width: 100%; padding: 2rem; box-sizing: border-box;
           background: white; text-align: left;
+          overflow: visible;
         }
-        .fc-card .github-diff-container {
-          margin: 12px 0; border: 1px solid rgb(226 232 240);
-          border-radius: 12px; overflow: hidden;
+        .fc-card .github-diff-container { margin: 12px 0; border: 1px solid rgb(226 232 240); border-radius: 12px; }
+        .fc-card .code-diff-content { margin: 12px 0; }
+        .fc-card .fc-diff-code {
+          display: block !important;
+          width: max-content !important;
+          min-width: 100%;
         }
-        .fc-card .github-diff-container pre { margin: 0 !important; }
+        .fc-card .fc-diff-code mark { display: inline; box-decoration-break: clone; -webkit-box-decoration-break: clone; }
         @media (max-width: 768px) {
           .fc-card.flipped .markdown-body { padding: 1.5rem; font-size: 0.95rem; }
         }
@@ -383,7 +386,7 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                         <span className="inline-block w-3 h-3 rounded-sm bg-amber-100/90 border border-amber-200/80" />
                         <span>밝은 배경은 이 질문과 연결된 부분이에요. 카드에 따라 표시가 없을 수도 있어요.</span>
                       </div>
-                      <div className="fc-back-content flex-1 min-h-0 overflow-auto">
+                      <div className="fc-back-content flex-1 min-h-0 min-w-0 overflow-auto">
                         {backViewMode === 'diff' ? (
                           card.metadata?.rawDiff ? (
                             <CodeDiffBlock diffContent={card.metadata.rawDiff} highlightStrings={card.highlights} />

--- a/app/src/templates/CodeDiffBlock.tsx
+++ b/app/src/templates/CodeDiffBlock.tsx
@@ -14,7 +14,7 @@ const MONO_STYLE: React.CSSProperties = {
 };
 
 function getDiffLineStyle(lineContent: string): React.CSSProperties {
-  const style: React.CSSProperties = { display: 'block' };
+  const style: React.CSSProperties = { display: 'block', whiteSpace: 'pre' };
   if (lineContent.startsWith('+') && !lineContent.startsWith('+++')) {
     style.backgroundColor = 'rgba(46, 160, 67, 0.15)';
     style.borderLeft = '3px solid #2ea043';
@@ -36,7 +36,7 @@ interface CodeDiffBlockProps {
 
 const CodeDiffBlock: React.FC<CodeDiffBlockProps> = ({ diffContent, highlightStrings }) => {
   return (
-    <div className="markdown-body code-diff-content">
+    <div className="markdown-body code-diff-content min-w-0">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
@@ -50,9 +50,9 @@ const CodeDiffBlock: React.FC<CodeDiffBlockProps> = ({ diffContent, highlightStr
                 const lines = raw.split('\n');
                 const hasHighlights = highlightStrings && highlightStrings.length > 0;
                 return (
-                  <div className="my-3 border border-slate-200 rounded-xl overflow-hidden">
-                    <pre className="m-0 p-3 overflow-x-auto" style={MONO_STYLE}>
-                      <code style={MONO_STYLE}>
+                  <div className="my-3 border border-slate-200 rounded-xl min-w-0 overflow-x-auto">
+                    <pre className="m-0 p-3 pr-6 min-w-0" style={{ ...MONO_STYLE, whiteSpace: 'pre' }}>
+                      <code className="fc-diff-code" style={{ ...MONO_STYLE, whiteSpace: 'pre' }}>
                         {hasHighlights
                           ? lines.map((line, i) => (
                               <div key={i} style={getDiffLineStyle(line)}>
@@ -95,9 +95,9 @@ const CodeDiffBlock: React.FC<CodeDiffBlockProps> = ({ diffContent, highlightStr
             </h2>
           ),
           h3: ({ children }) => (
-            <h3 className="text-[1.25em] font-semibold mt-5 mb-3 text-[#24292f] flex items-center gap-2">
-              <FileText className="w-5 h-5 shrink-0" aria-hidden />
-              {children}
+            <h3 className="text-[1.25em] font-semibold mt-5 mb-3 text-[#24292f] flex items-start gap-2 min-w-0">
+              <FileText className="w-5 h-5 shrink-0 mt-0.5" aria-hidden />
+              <span className="break-all min-w-0">{children}</span>
             </h3>
           ),
           strong: ({ children }) => {

--- a/app/src/templates/FileContentBlock.tsx
+++ b/app/src/templates/FileContentBlock.tsx
@@ -68,7 +68,7 @@ const FileContentBlock: React.FC<FileContentBlockProps> = ({ content, filename =
         ? injectHighlightMarkup(content, highlightStrings, HIGHLIGHT_CLASS)
         : content;
     return (
-      <div className="markdown-body w-full h-full overflow-y-auto p-6 box-border text-left bg-white">
+      <div className="markdown-body w-full p-6 box-border text-left bg-white">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeRaw]}
@@ -81,7 +81,7 @@ const FileContentBlock: React.FC<FileContentBlockProps> = ({ content, filename =
                     style={github}
                     language={match[1]}
                     PreTag="div"
-                    customStyle={{ margin: '0.5em 0', borderRadius: '6px', fontSize: '13px' }}
+                    customStyle={{ margin: '0.5em 0', borderRadius: '6px', fontSize: '13px', overflowX: 'auto' }}
                     codeTagProps={{
                       style: {
                         fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
@@ -113,11 +113,11 @@ const FileContentBlock: React.FC<FileContentBlockProps> = ({ content, filename =
 
   if (hasHighlights) {
     return (
-      <div className="w-full h-full overflow-auto p-4 bg-slate-50 rounded-b-3xl border border-slate-200 border-t-0 box-border">
-        <pre className="m-0 overflow-x-auto" style={MONO_STYLE}>
-          <code style={MONO_STYLE}>
+      <div className="w-full p-4 bg-slate-50 rounded-b-3xl border border-slate-200 border-t-0 box-border min-w-0">
+        <pre className="m-0 pr-4 overflow-x-auto min-w-0" style={{ ...MONO_STYLE, whiteSpace: 'pre' }}>
+          <code style={{ ...MONO_STYLE, whiteSpace: 'pre' }}>
             {lines.map((line, i) => (
-              <div key={i} className="block">
+              <div key={i} className="block whitespace-pre">
                 {highlightText(line, highlightStrings!)}
               </div>
             ))}
@@ -128,7 +128,7 @@ const FileContentBlock: React.FC<FileContentBlockProps> = ({ content, filename =
   }
 
   return (
-    <div className="w-full h-full overflow-auto p-4 bg-slate-50 rounded-b-3xl border border-slate-200 border-t-0 box-border">
+    <div className="w-full p-4 bg-slate-50 rounded-b-3xl border border-slate-200 border-t-0 box-border min-w-0">
       <SyntaxHighlighter
         style={github}
         language={language}
@@ -139,6 +139,7 @@ const FileContentBlock: React.FC<FileContentBlockProps> = ({ content, filename =
           background: 'transparent',
           fontSize: '13px',
           lineHeight: '1.45',
+          overflowX: 'auto',
         }}
         codeTagProps={{
           style: MONO_STYLE,


### PR DESCRIPTION
### Purpose

랜딩 데모 플래시카드에서 발생하던 코드 스니펫 텍스트 가로 잘림, 이중 세로 스크롤, diff 하이라이트 끊김, H3 파일명 가로 스크롤 문제를 수정합니다.

### Description

| 파일 | 변경 내용 |
|------|-----------|
| `CodeDiffBlock.tsx` | diff 라인 `whiteSpace: pre` 적용, `overflow-x-auto`를 외부 div로 이동, h3 파일명 `break-all`로 줄바꿈, `fc-diff-code` 클래스 추가, `code-diff-content`에 `min-w-0` 추가 |
| `FileContentBlock.tsx` | markdown/코드 영역 `overflow` 제거, `whiteSpace: pre` 적용, `SyntaxHighlighter`에 `overflowX: 'auto'` 추가, 코드 블록 `pr-4` 여백 추가 |
| `FlashCardPlayer.tsx` | `.fc-card.flipped .markdown-body`에서 `overflow-y`, `height: 100%` 제거, `fc-back-content`에 `min-w-0` 추가, `.fc-diff-code`에 `display: block`, `width: max-content` 오버라이드 (github-markdown-css 대응), `mark`에 `box-decoration-break: clone` 적용 |

**주요 수정 사항 요약**
- **코드 스니펫 가로 잘림**: `pre` > `code` 구조에서 `github-markdown-css`의 `display: inline` 때문에 `code`가 확장되지 않아, `.fc-diff-code`에서 `display: block`, `width: max-content`로 오버라이드
- **이중 세로 스크롤**: `markdown-body`와 `fc-back-content` 중 스크롤을 `fc-back-content` 하나만 담당하도록 변경
- **diff 하이라이트 끊김**: 스크롤을 외부 div로 모으고, `code`가 `width: max-content`로 확장되도록 변경
- **H3 파일명**: `flex items-center` → `flex items-start`로 변경하고, 파일명을 `break-all min-w-0` span으로 감싸 긴 경로 줄바꿈

### How to test

1. 랜딩 페이지(`/`)에서 예시 리포지토리(Spring Boot, Kubernetes 등)로 플래시카드 생성
2. 카드를 뒤집어 Diff 보기 확인
3. 다음 항목 검증:
   - 긴 코드 라인이 가로 스크롤로 전체 표시되는지
   - 세로 스크롤바가 한 개만 보이는지
   - 초록/파랑/빨강 diff 배경과 AI 하이라이트가 끊기지 않는지
   - 긴 파일 경로가 H3에서 줄바꿈되는지

### Review Requirement

- `github-markdown-css`의 `pre code` 스타일을 오버라이드하는 `.fc-diff-code` CSS가 다른 마크다운 코드 블록에 영향을 주지 않는지 확인 부탁드립니다.

### Additional Info

- **관련 Notion**: [✏️ 카드 UI 내 텍스트 깨짐 현상](https://www.notion.so/chucoding/UI-312fd64d44a0800884ade3a8ea3a117a)