### PR TITLE
[TSK-128] 브랜치 선택 기능 복원

### DIFF
--- a/app/src/api/github-api.ts
+++ b/app/src/api/github-api.ts
@@ -39,13 +39,15 @@ interface MarkdownResponse {
 export async function getCommits(
   since: Date,
   until: Date,
-  repositoryFullName?: string
+  repositoryFullName?: string,
+  branch?: string
 ): Promise<Commit[]> {
   const params: Record<string, string> = {
     since: since.toISOString(),
     until: until.toISOString(),
   };
   if (repositoryFullName) params.repositoryFullName = repositoryFullName;
+  if (branch) params.branch = branch;
 
   const response = await apiClient.get('/getCommits', { params });
   return response.data;
@@ -89,12 +91,6 @@ export async function getRepositories(): Promise<Repository[]> {
   return response.data;
 }
 
-/**
- * @deprecated
- * 과한 정보 제공으로 인해 사용하지 않음 2026-02-16
- * @TODO
- * 결제 기능 생기면 복구
- */
 export interface Branch {
   name: string;
   protected: boolean;

--- a/app/src/pages/LandingDemo.tsx
+++ b/app/src/pages/LandingDemo.tsx
@@ -65,7 +65,7 @@ const LandingDemo: React.FC = () => {
           <input
             type="text"
             className="flex-1 border-0 outline-none text-base py-3.5 px-3 bg-transparent text-text min-w-0 placeholder:text-text-muted max-[768px]:w-full max-[768px]:text-center max-[768px]:py-3"
-            placeholder="https://github.com/owner/repo"
+            placeholder="owner/repo 또는 owner/repo@브랜치명"
             value={repoUrl}
             onChange={(e) => setRepoUrl(e.target.value)}
             disabled={loading}
@@ -83,6 +83,12 @@ const LandingDemo: React.FC = () => {
           </button>
         </div>
       </form>
+
+      <p className="mt-4 text-xs text-text-muted leading-relaxed max-[768px]:text-center">
+        기본: owner/repo (예: facebook/react)
+        <br className="max-[768px]:block" />
+        다른 브랜치: owner/repo@브랜치명 (예: facebook/react@main)
+      </p>
 
       <div className="mt-6 w-full max-w-[100vw] md:max-w-none md:relative md:left-1/2 md:-translate-x-1/2 md:w-screen md:overflow-x-hidden" role="group" aria-label="예시 리포지토리">
         <div className="flex flex-wrap items-center justify-center gap-3 md:flex-nowrap md:justify-center">
@@ -123,6 +129,16 @@ const LandingDemo: React.FC = () => {
             )}
             renderFooter={() => (
               <div className="text-center mt-14 animate-fade-up">
+                {cards.length === 1 && (
+                  <p
+                    className="mb-6 mx-auto max-w-xl text-center text-xs text-text-muted leading-relaxed flex items-center justify-center gap-1.5 flex-wrap animate-fade-in"
+                    role="note"
+                    aria-label="브랜치 가이드"
+                  >
+                    <Info className="w-3.5 h-3.5 shrink-0 text-text-muted" aria-hidden />
+                    <span>기본 브랜치(main)에 커밋이 적을 수 있어요. 다른 브랜치를 쓰려면 owner/repo@브랜치명 형식으로 다시 시도해보세요.</span>
+                  </p>
+                )}
                 <p
                   className="mb-8 mx-auto max-w-xl text-center text-xs text-text-muted leading-relaxed flex items-center justify-center gap-1.5 flex-wrap"
                   role="note"

--- a/app/src/pages/LandingDemo.tsx
+++ b/app/src/pages/LandingDemo.tsx
@@ -65,7 +65,7 @@ const LandingDemo: React.FC = () => {
           <input
             type="text"
             className="flex-1 border-0 outline-none text-base py-3.5 px-3 bg-transparent text-text min-w-0 placeholder:text-text-muted max-[768px]:w-full max-[768px]:text-center max-[768px]:py-3"
-            placeholder="owner/repo 또는 owner/repo@브랜치명"
+            placeholder="https://github.com/owner/repo@branch"
             value={repoUrl}
             onChange={(e) => setRepoUrl(e.target.value)}
             disabled={loading}
@@ -83,12 +83,6 @@ const LandingDemo: React.FC = () => {
           </button>
         </div>
       </form>
-
-      <p className="mt-4 text-xs text-text-muted leading-relaxed max-[768px]:text-center">
-        기본: owner/repo (예: facebook/react)
-        <br className="max-[768px]:block" />
-        다른 브랜치: owner/repo@브랜치명 (예: facebook/react@main)
-      </p>
 
       <div className="mt-6 w-full max-w-[100vw] md:max-w-none md:relative md:left-1/2 md:-translate-x-1/2 md:w-screen md:overflow-x-hidden" role="group" aria-label="예시 리포지토리">
         <div className="flex flex-wrap items-center justify-center gap-3 md:flex-nowrap md:justify-center">

--- a/app/src/pages/Onboarding.tsx
+++ b/app/src/pages/Onboarding.tsx
@@ -2,11 +2,13 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { doc, setDoc } from 'firebase/firestore';
 import { auth, store } from '../firebase';
 import { trackEvent } from '../analytics';
-import { getRepositories } from '../api/github-api';
+import { getRepositories, getBranches } from '../api/github-api';
 import { Repository, UserRepository } from '../types';
-import { LayoutTemplate, TriangleAlert, CircleCheck, RefreshCw, Lightbulb, Smartphone, ChevronRight, ChevronDown } from 'lucide-react';
+import { LayoutTemplate, TriangleAlert, CircleCheck, RefreshCw, Lightbulb, Smartphone, ChevronRight, ChevronDown, GitBranch } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 interface OnboardingProps {
   onComplete: () => void;
@@ -21,6 +23,8 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
   const [saving, setSaving] = useState<boolean>(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   const [error, setError] = useState<{ type: 'repos' | 'save'; message: string } | null>(null);
+  const [branches, setBranches] = useState<{ name: string }[]>([]);
+  const [loadingBranches, setLoadingBranches] = useState<boolean>(false);
 
   // 리포지토리 목록 가져오기
   const fetchRepositories = useCallback(async () => {
@@ -54,6 +58,27 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
   const handleRepositorySelect = (repo: Repository) => {
     setSelectedRepo({ fullName: repo.full_name, url: repo.html_url });
     setIsDropdownOpen(false);
+    setBranches([]);
+  };
+
+  // selectedRepo 변경 시 브랜치 목록 로드
+  useEffect(() => {
+    if (!selectedRepo) {
+      setBranches([]);
+      setLoadingBranches(false);
+      return;
+    }
+    const [owner, repo] = selectedRepo.fullName.split('/');
+    if (!owner || !repo) return;
+    setLoadingBranches(true);
+    getBranches(owner, repo)
+      .then((list) => { setBranches(list); setLoadingBranches(false); })
+      .catch(() => { setBranches([]); setLoadingBranches(false); });
+  }, [selectedRepo?.fullName]);
+
+  const handleBranchChange = (value: string) => {
+    if (!selectedRepo) return;
+    setSelectedRepo({ ...selectedRepo, branch: value && value !== '__default__' ? value : undefined });
   };
 
   const handleSaveSettings = async () => {
@@ -70,8 +95,9 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
       setSaving(true);
       setError(null);
       const userDocRef = doc(store, 'users', auth.currentUser.uid);
+      const repoToSave = { fullName: selectedRepo.fullName, url: selectedRepo.url, ...(selectedRepo.branch ? { branch: selectedRepo.branch } : {}) };
       await setDoc(userDocRef, {
-        repositories: [selectedRepo],
+        repositories: [repoToSave],
         onboardingCompleted: true,
         onboardingSkipped: false,
         updatedAt: new Date().toISOString(),
@@ -243,6 +269,28 @@ const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
                     </div>
                   )}
                 </div>
+              </div>
+              {/* 브랜치 선택 (선택사항) */}
+              <div className="mt-4">
+                <Label htmlFor="branch-onboarding" className="block text-sm font-semibold text-text mb-2 flex items-center gap-1.5">
+                  <GitBranch className="w-4 h-4 shrink-0" aria-hidden />
+                  브랜치 (선택사항)
+                </Label>
+                <Select
+                  value={selectedRepo?.branch || '__default__'}
+                  onValueChange={handleBranchChange}
+                  disabled={!selectedRepo || loadingBranches || saving}
+                >
+                  <SelectTrigger id="branch-onboarding" className="w-full">
+                    <SelectValue placeholder={selectedRepo ? (loadingBranches ? '로딩 중...' : '기본 브랜치 (main)') : '리포지토리를 먼저 선택하세요'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__default__">기본 브랜치 (main)</SelectItem>
+                    {branches.map((b) => (
+                      <SelectItem key={b.name} value={b.name}>{b.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
 

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -531,7 +531,7 @@ const Settings: React.FC = () => {
                 'Free'
               )}
             </span>
-            {/* TODO: 준비 완료 시 onClick을 navigateToPricing으로 복구 */}
+            {/* TODO: 준비 완료 시 onClick을 setCurrentPage('pricing') 복구 */}
             {tier === 'free' && (
               <Button
                 type="button"

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -28,6 +28,8 @@ export interface Repository {
 export interface UserRepository {
   fullName: string;
   url: string;
+  /** 브랜치 (없으면 default branch 사용) */
+  branch?: string;
 }
 
 /**


### PR DESCRIPTION
### Purpose

main 브랜치에 커밋이 거의 없고 develop/feature 브랜치에서 작업하는 경우를 지원하기 위해 TSK-62에서 제거했던 브랜치 선택 기능을 다시 추가합니다.

### Description

**데이터 모델**
- `UserRepository`에 `branch?: string` 추가 (`app/src/types.ts`, `functions/src/github.ts`)

**백엔드**
- `getCommits`: GitHub API URL에 `sha` 쿼리 파라미터 추가
- `repositoryFullName`으로 해당 레포의 `branch` 조회 후 전달, 없으면 default branch 사용

**프론트엔드**
- **Settings**: 레포 카드 하단에 브랜치 Select 추가, `getBranches` 호출
- **Onboarding**: Step 2에 "브랜치 (선택사항)" Select 추가
- **useTodayFlashcards**: `getCommits` 호출 시 `repo.branch` 전달
- **LandingDemo**: `owner/repo@branch` 파싱, placeholder `https://github.com/owner/repo@branch`, 도움말 제거, 카드 1개일 때 브랜치 가이드 노출

**기타**
- Radix UI Select `value=""` 제한으로 인해 기본 브랜치 옵션을 `value="__default__"`로 사용

| 파일 | 변경 내용 |
|------|-----------|
| app/src/types.ts | UserRepository.branch 추가 |
| app/src/api/github-api.ts | getCommits에 branch 파라미터, getBranches deprecated 제거 |
| functions/src/github.ts | UserRepository.branch, getCommits에 sha 전달 |
| app/src/hooks/useTodayFlashcards.ts | getCommits 호출 시 branch 전달 |
| app/src/pages/Settings.tsx | 레포별 브랜치 Select, getBranches 호출 |
| app/src/pages/Onboarding.tsx | 브랜치 Select 추가 |
| app/src/lib/demoFlashcards.ts | parseGitHubUrl @branch 파싱, commits API sha |
| app/src/pages/LandingDemo.tsx | placeholder, 도움말 제거, 카드 1개 시 가이드 |

### How to test

1. **Settings**: 설정 페이지 진입 → 레포 선택 후 브랜치 Select 표시 확인 → 브랜치 선택 후 저장 → 플래시카드가 해당 브랜치 커밋 기준으로 생성되는지 확인
2. **Onboarding**: 신규 로그인 후 온보딩 Step 2에서 레포 선택 → 브랜치 Select 활성화 확인 → 브랜치 선택 후 완료
3. **랜딩 데모**: `https://github.com/facebook/react` 또는 `https://github.com/facebook/react@main` 입력 후 Generate → 플래시카드 생성 확인. 카드 1개일 때 브랜치 가이드 노출 확인

### Review Requirement

- Settings/Onboarding에서 브랜치 Select가 Radix UI `value=""` 제한을 우회하기 위해 `__default__`를 쓰는 부분이 올바른지
- Firestore `users.repositories`에 `branch`를 저장·조회하는 흐름이 의도대로 동작하는지

### Additional Info

- 관련 Notion: [🔀 브랜치 선택 기능 복원](https://www.notion.so/chucoding/312fd64d44a080e49891dcdbb52f7ac2)