### PR TITLE
[TSK-129] 플래시카드 로딩 UI 개선 - 로딩 메시지 분리 및 모바일 반응형 적용

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -121,17 +121,38 @@ const App: React.FC = () => {
     return <Login />;
   }
 
-  // 로딩 중 (인증, 온보딩 확인, 데이터 로딩)
-  if (authLoading || !onboardingChecked || loading) {
+  // 일반 로딩 (인증·온보딩 확인 중)
+  if (authLoading || !onboardingChecked) {
     return (
-      <>
-        <Card>
-          <div className="w-[50px] h-[50px] border-[3px] border-white/30 border-t-white rounded-full animate-spin mx-auto mb-5"></div>
-          <h2 className="mb-2.5 text-xl flex items-center justify-center gap-2"><BookOpen className="w-6 h-6 shrink-0" aria-hidden />플래시카드 준비 중</h2>
-          <p className="text-base">GitHub에서 최근 커밋을 분석하고 있습니다...</p>
-          <p className="mt-2.5 text-[0.9rem] opacity-80 flex items-center justify-center gap-1.5"><Clock className="w-4 h-4 shrink-0" aria-hidden />데이터 양에 따라 시간이 조금 걸릴 수 있습니다</p>
-        </Card>
-      </>
+      <Card>
+        <div className="w-[50px] h-[50px] max-[768px]:w-10 max-[768px]:h-10 border-[3px] border-white/30 border-t-white rounded-full animate-spin mx-auto mb-4 max-[768px]:mb-3" aria-hidden />
+        <h2 className="text-xl max-[768px]:text-lg flex items-center justify-center gap-2 whitespace-nowrap">
+          <BookOpen className="w-6 h-6 max-[768px]:w-5 max-[768px]:h-5 shrink-0" aria-hidden />
+          잠시만 기다려주세요
+        </h2>
+      </Card>
+    );
+  }
+
+  // 플래시카드 로딩 (GitHub 분석·AI 생성 중)
+  if (loading) {
+    return (
+      <Card>
+        <div className="w-[50px] h-[50px] max-[768px]:w-10 max-[768px]:h-10 border-[3px] border-white/30 border-t-white rounded-full animate-spin mx-auto mb-4 max-[768px]:mb-3" aria-hidden />
+        <h2 className="mb-2.5 text-xl max-[768px]:text-lg flex items-center justify-center gap-2">
+          <BookOpen className="w-6 h-6 max-[768px]:w-5 max-[768px]:h-5 shrink-0" aria-hidden />
+          플래시카드 준비 중
+        </h2>
+        <p className="text-base max-[768px]:text-sm whitespace-nowrap overflow-hidden text-ellipsis">
+          <span className="hidden md:inline">GitHub에서 최근 커밋을 분석하고 있습니다...</span>
+          <span className="md:hidden">커밋 분석 중...</span>
+        </p>
+        <p className="mt-2.5 text-[0.9rem] max-[768px]:text-xs opacity-80 flex items-center justify-center gap-1.5 whitespace-nowrap overflow-hidden text-ellipsis">
+          <Clock className="w-4 h-4 max-[768px]:w-3 max-[768px]:h-3 shrink-0" aria-hidden />
+          <span className="hidden md:inline">데이터 양에 따라 시간이 조금 걸릴 수 있습니다</span>
+          <span className="md:hidden">잠시만 기다려주세요</span>
+        </p>
+      </Card>
     );
   }
 

--- a/app/src/components/Card.tsx
+++ b/app/src/components/Card.tsx
@@ -9,7 +9,7 @@ interface CardProps {
 const Card: React.FC<CardProps> = ({ children, className = '' }) => {
   return (
     <div className="flex flex-col h-screen items-center justify-center bg-background text-foreground text-center p-4">
-      <ShadcnCard className={`rounded-2xl p-10 border border-border shadow-[0_8px_32px_rgba(0,0,0,0.3)] max-w-[400px] w-full ${className}`}>
+      <ShadcnCard className={`rounded-2xl p-6 max-[768px]:p-4 border border-border shadow-[0_8px_32px_rgba(0,0,0,0.3)] max-w-[400px] w-full ${className}`}>
         <CardContent className="p-0 pt-0">
           {children}
         </CardContent>


### PR DESCRIPTION
### Purpose

플래시카드 로딩 UI를 개선하여, 인증·온보딩 확인 중에는 "잠시만 기다려주세요", 실제 플래시카드 로드 중에만 "플래시카드 준비 중" 메시지가 보이도록 변경합니다. 모바일에서 텍스트가 한 줄로 보이도록 반응형 디자인을 적용합니다.

### Description

- **로딩 상태 분리**
  - `authLoading || !onboardingChecked`: 스피너 + "잠시만 기다려주세요"
  - `loading` (useTodayFlashcards): 스피너 + "플래시카드 준비 중" + GitHub 분석 관련 문구
- **모바일 반응형 텍스트**
  - 데스크탑 (768px↑): "GitHub에서 최근 커밋을 분석하고 있습니다...", "데이터 양에 따라 시간이 조금 걸릴 수 있습니다"
  - 모바일 (768px↓): "커밋 분석 중...", "잠시만 기다려주세요"
  - `hidden md:inline` / `md:hidden`로 화면 크기별 문구 분기, `whitespace-nowrap overflow-hidden text-ellipsis`로 한 줄 표시 유지
- **카드 반응형 디자인**
  - 스피너·제목·아이콘에 `max-[768px]:` 반응형 클래스 적용
  - Card 컴포넌트 패딩: `p-10` → `p-6 max-[768px]:p-4`

**수정된 파일**

| 파일 | 변경 내용 |
|------|----------|
| `app/src/App.tsx` | 로딩 조건 분리, 반응형 클래스 적용 |
| `app/src/components/Card.tsx` | 모바일 패딩 조정 (`p-6 max-[768px]:p-4`) |

### How to test

1. `pnpm run dev`로 앱 실행
2. **일반 로딩**: 비로그인 상태에서 로그인 직후, 인증·온보딩 확인 구간에서 "잠시만 기다려주세요"가 뜨는지 확인
3. **플래시카드 로딩**: 온보딩 완료 후 플래시카드 로드 중에만 "플래시카드 준비 중" + "GitHub에서 최근 커밋을 분석하고 있습니다..."가 뜨는지 확인
4. **모바일 반응형**: 개발자 도구로 375px, 768px 기준으로 너비 조절 후, 텍스트가 한 줄로 보이는지 확인

### Review Requirement

- 로딩 조건 분리(`authLoading` / `!onboardingChecked` vs `loading`)가 의도대로 동작하는지
- 모바일에서 텍스트가 한 줄로 잘 표시되는지
- Card 패딩 변경이 다른 사용처(Login, NoDataView 등)에 문제가 없는지

### Additional Info

- **관련 Notion**: [플래시카드 로딩(텍스트 줄바꿈 깨짐 및 준비중 아닐때도 로딩 나타남)](https://www.notion.so/chucoding/313fd64d44a0808bb2efccdda564175c)