### PR TITLE
[TSK-130] 앱 재활성화 시 날짜 변경 감지 및 플래시카드 자동 재로드

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,7 @@ import Onboarding from './pages/Onboarding';
 import Card from './components/Card';
 import { Button } from '@/components/ui/button';
 import { useTodayFlashcards } from './hooks/useTodayFlashcards';
+import { useVisibilityDateCheck } from './hooks/useVisibilityDateCheck';
 import { useNavigationStore } from './stores/navigationStore';
 import { BookOpen, ArrowLeft, Settings as SettingsIcon, Clock } from 'lucide-react';
 
@@ -34,6 +35,9 @@ const App: React.FC = () => {
   
   // 오늘의 플래시카드 데이터 로드 (user가 null이면 로드하지 않음)
   const { loading, hasData } = useTodayFlashcards(user);
+
+  // 앱 재활성화 시 날짜 변경 감지 → 하루 지났으면 플래시카드 재로드 (PWA 백그라운드 대응)
+  useVisibilityDateCheck(!!user);
 
   /* 인증 상태 감지 */
   useEffect(() => {

--- a/app/src/hooks/useVisibilityDateCheck.ts
+++ b/app/src/hooks/useVisibilityDateCheck.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useNavigationStore } from '../stores/navigationStore';
+import { getCurrentDate } from '../modules/utils';
+
+const DEBOUNCE_MS = 250;
+
+/**
+ * 앱이 다시 활성화될 때(visibilitychange, pageshow, focus) 날짜가 바뀌었는지 확인하고,
+ * 오늘 뷰에서 하루가 지났으면 플래시카드 재로드를 트리거함.
+ * PWA/탭이 백그라운드에 있다가 다시 포그라운드로 돌아올 때 유효.
+ */
+export function useVisibilityDateCheck(enabled: boolean) {
+  const selectedPastDate = useNavigationStore((s) => s.selectedPastDate);
+  const lastLoadedDateKey = useNavigationStore((s) => s.lastLoadedDateKey);
+  const triggerFlashcardReload = useNavigationStore((s) => s.triggerFlashcardReload);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const checkAndReloadIfNeeded = useCallback(() => {
+    if (!enabled || typeof document === 'undefined' || document.visibilityState !== 'visible') {
+      return;
+    }
+    // 과거 날짜 보는 중에는 건드리지 않음
+    if (selectedPastDate !== null) {
+      return;
+    }
+    if (!lastLoadedDateKey) {
+      return;
+    }
+    const todayKey = getCurrentDate();
+    if (todayKey !== lastLoadedDateKey) {
+      triggerFlashcardReload();
+    }
+  }, [enabled, selectedPastDate, lastLoadedDateKey, triggerFlashcardReload]);
+
+  const debouncedCheck = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = setTimeout(checkAndReloadIfNeeded, DEBOUNCE_MS);
+  }, [checkAndReloadIfNeeded]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    document.addEventListener('visibilitychange', debouncedCheck);
+    window.addEventListener('pageshow', debouncedCheck);
+    window.addEventListener('focus', debouncedCheck);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      document.removeEventListener('visibilitychange', debouncedCheck);
+      window.removeEventListener('pageshow', debouncedCheck);
+      window.removeEventListener('focus', debouncedCheck);
+    };
+  }, [enabled, debouncedCheck]);
+}

--- a/app/src/pages/FlashCardViewer.tsx
+++ b/app/src/pages/FlashCardViewer.tsx
@@ -18,6 +18,7 @@ import { doc, getDoc } from 'firebase/firestore';
 import { FlashCardPlayer } from '../features/flashcard';
 import type { FlashCard } from '../features/flashcard';
 import { auth, store } from '../firebase';
+import { useNavigationStore } from '../stores/navigationStore';
 import { getCurrentDate, shuffleArray } from '../modules/utils';
 import { Shuffle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -32,6 +33,7 @@ const FlashCardViewer: React.FC = () => {
   const [shuffleKey, setShuffleKey] = useState(0);
   const [currentSlide, setCurrentSlide] = useState(0);
   const isMobile = useIsMobile();
+  const flashcardReloadTrigger = useNavigationStore((s) => s.flashcardReloadTrigger);
 
   useEffect(() => {
     const user = auth.currentUser;
@@ -49,7 +51,7 @@ const FlashCardViewer: React.FC = () => {
         setCards([]);
       }
     });
-  }, []);
+  }, [flashcardReloadTrigger]);
 
   const handleShuffleDeck = useCallback(() => {
     setCards((prev) => shuffleArray(prev));

--- a/app/src/stores/navigationStore.ts
+++ b/app/src/stores/navigationStore.ts
@@ -5,9 +5,12 @@ export type Page = 'flashcard' | 'settings' | 'pricing';
 interface NavigationState {
   currentPage: Page;
   flashcardReloadTrigger: number;
+  lastLoadedDateKey: string | null;
   selectedPastDate: string | null;
   setCurrentPage: (page: Page) => void;
   setSelectedPastDate: (date: string | null) => void;
+  setLastLoadedDateKey: (date: string | null) => void;
+  triggerFlashcardReload: () => void;
   navigateToSettings: () => void;
   navigateToFlashcard: () => void;
   navigateToPricing: () => void;
@@ -16,9 +19,13 @@ interface NavigationState {
 export const useNavigationStore = create<NavigationState>((set) => ({
   currentPage: 'flashcard',
   flashcardReloadTrigger: 0,
+  lastLoadedDateKey: null,
   selectedPastDate: null,
   setCurrentPage: (page) => set({ currentPage: page }),
   setSelectedPastDate: (date) => set({ selectedPastDate: date }),
+  setLastLoadedDateKey: (date) => set({ lastLoadedDateKey: date }),
+  triggerFlashcardReload: () =>
+    set((state) => ({ flashcardReloadTrigger: state.flashcardReloadTrigger + 1 })),
   navigateToSettings: () => set({ currentPage: 'settings' }),
   navigateToFlashcard: () => set({ currentPage: 'flashcard' }),
   navigateToPricing: () => set({ currentPage: 'pricing' }),


### PR DESCRIPTION
### Purpose

PWA가 백그라운드에서 하루가 지난 뒤 다시 포그라운드로 돌아올 때, 마지막 로드된 날짜와 현재 날짜를 비교하여 날짜가 바뀌었으면 플래시카드를 자동으로 재로드한다.

### Description

**배경**: PWA는 탭을 끄지 않고 열어둔 채 자정이 지나도 기존에는 새 날짜 데이터로 갱신되지 않았다. `useTodayFlashcards`, `FlashCardViewer`가 마운트 시에만 실행되어, 2/27 23시에 앱을 열고 2/28 아침에 돌아오면 어제(2/27) 데이터가 계속 보이는 문제가 있었다.

**해결**: 앱 재활성화 시(`visibilitychange`, `pageshow`, `focus`) 날짜를 비교하고, 하루가 지났으면 재로드하는 패턴 1을 적용했다.

| 파일 | 변경 내용 |
|------|----------|
| `app/src/stores/navigationStore.ts` | `lastLoadedDateKey`, `setLastLoadedDateKey`, `triggerFlashcardReload` 추가 |
| `app/src/hooks/useVisibilityDateCheck.ts` | 신규 훅 — visibility 이벤트 리스너 + debounce(250ms) + 날짜 비교 후 재로드 트리거 |
| `app/src/hooks/useTodayFlashcards.ts` | 로드 성공 시 `setLastLoadedDateKey(todayDate)` 호출, 실패/레포 없음 시 `setLastLoadedDateKey(null)` |
| `app/src/pages/FlashCardViewer.tsx` | `useEffect` 의존 배열에 `flashcardReloadTrigger` 추가 |
| `app/src/App.tsx` | 로그인 시 `useVisibilityDateCheck(!!user)` 호출 |

**동작 요약**:
- 마지막 로드 날짜를 `lastLoadedDateKey`에 저장
- 앱이 보이는 순간 `getCurrentDate()`와 비교
- 다르면 `triggerFlashcardReload()` 호출 → `useTodayFlashcards`와 `FlashCardViewer`가 재로드
- `selectedPastDate !== null`(과거 날짜 복습 중)일 때는 재로드 트리거 없음

### How to test

1. 로그인 후 플래시카드 화면에서 오늘 날짜 데이터가 로드되었는지 확인한다.
2. 브라우저 개발자 도구 → Console에서 `new Date().toLocaleDateString('en-CA')`로 현재 날짜를 확인한다.
3. 시스템 시간을 내일로 변경하거나, `lastLoadedDateKey`를 DevTools로 어제로 강제 변경한다.
4. 다른 탭으로 이동했다가 앱 탭으로 돌아온다(`visibilitychange` 시뮬레이션).
5. 플래시카드가 새 날짜 기준으로 다시 로드되는지 확인한다.

**간단 확인**: 과거 날짜 복습 화면에 있을 때 탭 전환 후 돌아와도 재로드가 트리거되지 않는지 확인한다.

### Review Requirement

- `useVisibilityDateCheck` 훅에서 debounce, `selectedPastDate` 조건이 올바른지 검토해 주세요.
- `useTodayFlashcards`에서 `setLastLoadedDateKey`를 호출하는 모든 분기(성공/실패/레포 없음)가 적절한지 확인해 주세요.

### Additional Info

- 관련 Notion: [🔃 모바일 환경에서 하루 지나면 자동 새로고침](https://www.notion.so/chucoding/313fd64d44a08051a52fc0089bbfa74f)
- 타임존: `getCurrentDate()`는 로컬 타임존 기준(`toLocaleDateString('en-CA')`)을 그대로 사용한다.