### PR TITLE
[TSK-132] Diff/파일 보기 탭 UX, 에러 처리, 스크롤·스와이프 우선 처리 개선

### DIFF
--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -5,7 +5,7 @@ import FileContentBlock from '../../templates/FileContentBlock';
 import { getFileContent, getMarkdown } from '../../api/github-api';
 import type { FlashCard } from './types';
 import { trackEvent } from '../../analytics';
-import { Sparkles, Folder } from 'lucide-react';
+import { Sparkles, Folder, GitCompare, FileText } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -333,50 +333,27 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                           type="button"
                           role="tab"
                           aria-selected={backViewMode === 'diff'}
-                          className={`fc-tab min-w-[100px] py-2 px-3 rounded-xl text-sm font-medium transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${backViewMode === 'diff' ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-slate-800 hover:bg-slate-100'}`}
+                          aria-label="Diff 보기"
+                          title="Diff 보기"
+                          className={`fc-tab flex items-center justify-center gap-1.5 w-9 h-9 sm:min-w-[88px] sm:w-auto sm:py-2 sm:px-3 rounded-xl text-sm font-medium transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${backViewMode === 'diff' ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-slate-800 hover:bg-slate-100'}`}
                           onClick={() => setBackViewMode('diff')}
                         >
-                          Diff 보기
+                          <GitCompare className="w-4 h-4 shrink-0" aria-hidden />
+                          <span className="hidden sm:inline">Diff 보기</span>
                         </button>
                         <button
                           type="button"
                           role="tab"
                           aria-selected={backViewMode === 'file'}
+                          aria-label="파일 보기"
+                          title="파일 보기"
                           disabled={!hasFileView}
-                          className={`fc-tab min-w-[100px] py-2 px-3 rounded-xl text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${backViewMode === 'file' ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-slate-800 hover:bg-slate-100'} ${hasFileView ? 'cursor-pointer' : ''}`}
+                          className={`fc-tab flex items-center justify-center gap-1.5 w-9 h-9 sm:min-w-[88px] sm:w-auto sm:py-2 sm:px-3 rounded-xl text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${backViewMode === 'file' ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-slate-800 hover:bg-slate-100'} ${hasFileView ? 'cursor-pointer' : ''}`}
                           onClick={() => hasFileView && setBackViewMode('file')}
                         >
-                          파일 보기
+                          <FileText className="w-4 h-4 shrink-0" aria-hidden />
+                          <span className="hidden sm:inline">파일 보기</span>
                         </button>
-                        {backViewMode === 'file' && hasFilesArray && effectiveFiles.length > 1 && (
-                          <Select
-                            value={String(safeFileIndex)}
-                            onValueChange={(value) => {
-                              setSelectedFileIndex(Number(value));
-                              lastFetchedUrlRef.current = null;
-                            }}
-                          >
-                            <SelectTrigger
-                              className="ml-2 h-8 min-w-0 max-w-[200px] rounded-xl border border-slate-200 bg-white px-2 text-xs text-slate-800 focus:ring-primary focus:ring-offset-1"
-                              onClick={(e) => e.stopPropagation()}
-                              aria-label="파일 선택"
-                            >
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent onClick={(e) => e.stopPropagation()}>
-                              {effectiveFiles.map((f, i) => (
-                                <SelectItem key={i} value={String(i)} title={f.filename}>
-                                  <span className="truncate block max-w-[180px]">{f.filename}</span>
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        )}
-                        {backViewMode === 'file' && hasFileView && effectiveFiles.length === 1 && (
-                          <span className="ml-2 text-xs text-slate-500 truncate max-w-[180px]" title={currentFilename}>
-                            {currentFilename}
-                          </span>
-                        )}
                       </div>
                       <div
                         className="fc-highlight-guide flex items-center gap-1.5 px-3 py-1.5 border-b border-slate-100 bg-amber-50/60 text-slate-600 text-[11px] shrink-0"
@@ -386,22 +363,70 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                         <span className="inline-block w-3 h-3 rounded-sm bg-amber-100/90 border border-amber-200/80" />
                         <span>밝은 배경은 이 질문과 연결된 부분이에요. 카드에 따라 표시가 없을 수도 있어요.</span>
                       </div>
-                      <div className="fc-back-content flex-1 min-h-0 min-w-0 overflow-auto">
-                        {backViewMode === 'diff' ? (
-                          card.metadata?.rawDiff ? (
-                            <CodeDiffBlock diffContent={card.metadata.rawDiff} highlightStrings={card.highlights} />
-                          ) : (
-                            <div className="p-6 text-slate-500 text-sm">코드 변경 내용이 없습니다. 파일 보기에서 확인하세요.</div>
-                          )
-                        ) : fileLoading ? (
-                          <div className="p-6 text-slate-500 text-sm">파일 내용을 불러오는 중...</div>
-                        ) : fileError ? (
-                          <div className="p-6 text-[#cf222e] text-sm">{fileError}</div>
-                        ) : fileContent !== null ? (
-                          <FileContentBlock content={fileContent} filename={currentFilename} highlightStrings={card.highlights} />
-                        ) : (
-                          <div className="p-6 text-slate-500 text-sm">파일 정보가 없습니다.</div>
+                      <div className="fc-back-content flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
+                        {backViewMode === 'file' && hasFileView && (
+                          <div
+                            className="shrink-0 px-3 py-2 border-b border-slate-200 bg-white space-y-2"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            {card.metadata?.repositoryFullName && (
+                              <a
+                                href={`https://github.com/${card.metadata.repositoryFullName}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1.5 text-[0.75rem] font-mono text-slate-600 no-underline transition-colors duration-200 hover:text-slate-800 hover:underline"
+                              >
+                                <Folder className="w-3.5 h-3.5 shrink-0" aria-hidden />
+                                <span className="truncate max-w-full" title={card.metadata.repositoryFullName}>{card.metadata.repositoryFullName}</span>
+                              </a>
+                            )}
+                            {hasFilesArray && effectiveFiles.length > 1 ? (
+                              <Select
+                                value={String(safeFileIndex)}
+                                onValueChange={(value) => {
+                                  setSelectedFileIndex(Number(value));
+                                  lastFetchedUrlRef.current = null;
+                                }}
+                              >
+                                <SelectTrigger
+                                  className="h-8 w-full max-w-full rounded-xl border border-slate-200 bg-white px-3 text-xs text-slate-800 focus:ring-primary focus:ring-offset-1"
+                                  onClick={(e) => e.stopPropagation()}
+                                  aria-label="파일 선택"
+                                >
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent onClick={(e) => e.stopPropagation()}>
+                                  {effectiveFiles.map((f, i) => (
+                                    <SelectItem key={i} value={String(i)} title={f.filename}>
+                                      <span className="truncate block max-w-[240px]">{f.filename}</span>
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            ) : (
+                              <span className="text-xs text-slate-500 truncate block" title={currentFilename}>
+                                {currentFilename}
+                              </span>
+                            )}
+                          </div>
                         )}
+                        <div className="flex-1 min-h-0 overflow-auto">
+                          {backViewMode === 'diff' ? (
+                            card.metadata?.rawDiff ? (
+                              <CodeDiffBlock diffContent={card.metadata.rawDiff} highlightStrings={card.highlights} />
+                            ) : (
+                              <div className="p-6 text-slate-500 text-sm">코드 변경 내용이 없습니다. 파일 보기에서 확인하세요.</div>
+                            )
+                          ) : fileLoading ? (
+                            <div className="p-6 text-slate-500 text-sm">파일 내용을 불러오는 중...</div>
+                          ) : fileError ? (
+                            <div className="p-6 text-[#cf222e] text-sm">{fileError}</div>
+                          ) : fileContent !== null ? (
+                            <FileContentBlock content={fileContent} filename={currentFilename} highlightStrings={card.highlights} />
+                          ) : (
+                            <div className="p-6 text-slate-500 text-sm">파일 정보가 없습니다.</div>
+                          )}
+                        </div>
                       </div>
                       {/* 하단 플로팅: Diff/파일 보기 토글과 무관하게 항상 노출 */}
                       <AIAnswerFloatingBlock answer={card.answer} />

--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -4,6 +4,7 @@ import CodeDiffBlock from '../../templates/CodeDiffBlock';
 import FileContentBlock from '../../templates/FileContentBlock';
 import { getFileContent, getMarkdown } from '../../api/github-api';
 import { formatFileErrorForUser } from '../../lib/formatError';
+import { useScrollPriorityTouch } from '../../lib/useScrollPriorityTouch';
 import type { FlashCard } from './types';
 import { trackEvent } from '../../analytics';
 import { Sparkles, Folder, GitCompare, FileText, WifiOff, RefreshCw } from 'lucide-react';
@@ -71,6 +72,7 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
   const [fileFetchTrigger, setFileFetchTrigger] = useState(0);
   const lastFetchedUrlRef = useRef<string | null>(null);
   const sliderRef = useRef<Slider>(null);
+  const { onTouchStartCapture, onTouchMoveCapture } = useScrollPriorityTouch();
 
   const next = () => {
     setFlipped(false);
@@ -205,6 +207,10 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
           to { opacity: 1; transform: translateY(0); }
         }
         .fc-player .slick-list { z-index: 1; overflow: visible; }
+        /* 스크롤 영역에서 가로 스크롤 우선: 터치 시 스와이프 대신 스크롤 처리 (모바일) */
+        .fc-scroll-area,
+        .fc-card .overflow-x-auto,
+        .fc-card pre { touch-action: pan-x pan-y; }
         .fc-player .slick-track { display: flex; align-items: center; }
         .fc-player .slick-dots { position: relative; bottom: -28px; }
         .fc-player .slick-dots li { margin: 0 6px; }
@@ -420,7 +426,11 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                             )}
                           </div>
                         )}
-                        <div className="flex-1 min-h-0 overflow-auto">
+                        <div
+                          className="fc-scroll-area flex-1 min-h-0 overflow-auto"
+                          onTouchStartCapture={onTouchStartCapture}
+                          onTouchMoveCapture={onTouchMoveCapture}
+                        >
                           {backViewMode === 'diff' ? (
                             card.metadata?.rawDiff ? (
                               <CodeDiffBlock diffContent={card.metadata.rawDiff} highlightStrings={card.highlights} />

--- a/app/src/lib/demoFlashcards.ts
+++ b/app/src/lib/demoFlashcards.ts
@@ -197,6 +197,7 @@ export async function generateDemoFlashcards(repoUrl: string): Promise<GenerateD
     })
   );
 
+  const repositoryFullName = `${parsed.owner}/${parsed.repo}`;
   const cards: FlashCard[] = detailedCommits.map((commit, i) => {
     const rawDiff = buildRawDiff(commit);
     const files = toFileChangeList(commit.files, parsed.owner, parsed.repo, commit.sha);
@@ -205,6 +206,7 @@ export async function generateDemoFlashcards(repoUrl: string): Promise<GenerateD
       answer: aiPairs[i].answer,
       metadata: {
         commitMessage: commit.commit.message.split('\n')[0],
+        repositoryFullName,
         ...(rawDiff && { rawDiff }),
         ...(files.length > 0 && { files }),
       },

--- a/app/src/lib/formatError.ts
+++ b/app/src/lib/formatError.ts
@@ -1,0 +1,13 @@
+/**
+ * 기술적 에러 메시지를 유저 친화적 한글로 변환
+ * 네트워크, API 오류 등 사용자 노출용 메시지 정규화
+ */
+export function formatFileErrorForUser(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('network') || lower.includes('network error')) return '인터넷 연결을 확인해주세요.';
+  if (lower.includes('timeout') || lower.includes('time out')) return '요청이 너무 오래 걸렸어요. 잠시 후 다시 시도해주세요.';
+  if (lower.includes('404') || lower.includes('not found')) return '파일을 찾을 수 없어요.';
+  if (lower.includes('403') || lower.includes('forbidden')) return '접근 권한이 없어요.';
+  if (lower.includes('500') || lower.includes('server')) return '서버에 일시적인 문제가 있어요. 잠시 후 다시 시도해주세요.';
+  return '파일을 불러오지 못했어요. 다시 시도해주세요.';
+}

--- a/app/src/lib/useScrollPriorityTouch.ts
+++ b/app/src/lib/useScrollPriorityTouch.ts
@@ -1,0 +1,39 @@
+import { useRef, useCallback } from 'react';
+
+/**
+ * 가로 스크롤 영역에서 스크롤 우선, 스크롤 끝에서만 부모(예: Slick) 스와이프 허용.
+ * CodeDiffBlock/FileContentBlock 내부 overflow-x 컨테이너도 대상.
+ * 터치 시 스크롤 가능하면 stopPropagation으로 부모 전파 차단.
+ */
+export function useScrollPriorityTouch() {
+  const touchStartRef = useRef<{ x: number; scrollEl: HTMLElement | null }>({ x: 0, scrollEl: null });
+
+  const onTouchStartCapture = useCallback((e: React.TouchEvent) => {
+    const container = e.currentTarget as HTMLElement;
+    let scrollEl: HTMLElement | null = null;
+    let node: HTMLElement | null = e.target as HTMLElement;
+    while (node && node !== container.parentElement) {
+      const style = getComputedStyle(node);
+      const ox = style.overflowX;
+      if ((ox === 'auto' || ox === 'scroll') && node.scrollWidth > node.clientWidth) {
+        scrollEl = node;
+        break;
+      }
+      node = node.parentElement;
+    }
+    touchStartRef.current = { x: e.touches[0].clientX, scrollEl: scrollEl ?? container };
+  }, []);
+
+  const onTouchMoveCapture = useCallback((e: React.TouchEvent) => {
+    const { x, scrollEl } = touchStartRef.current;
+    if (!scrollEl) return;
+    const deltaX = e.touches[0].clientX - x;
+    const { scrollLeft, scrollWidth, clientWidth } = scrollEl;
+    const canScrollLeft = scrollLeft > 0;
+    const canScrollRight = scrollLeft < scrollWidth - clientWidth - 1;
+    if (deltaX > 0 && canScrollLeft) e.stopPropagation();
+    else if (deltaX < 0 && canScrollRight) e.stopPropagation();
+  }, []);
+
+  return { onTouchStartCapture, onTouchMoveCapture };
+}


### PR DESCRIPTION
### Purpose

플래시카드 뒷면의 Diff/파일 보기 탭 모바일 UX 개선, 파일 API 에러 처리 개선, 가로 스크롤과 스와이프 충돌 해결을 위한 PR입니다.

### Description

#### 1. 탭 버튼 아이콘화 및 파일 Select 위치 변경
- **문제**: 모바일에서 "Diff 보기", "파일 보기" 버튼이 `min-w-[100px]`로 인해 두 줄로 표시됨
- **해결**:
  - 640px 이하: 아이콘만 표시 (`GitCompare`, `FileText`)
  - 640px 이상: 아이콘 + 텍스트
  - `aria-label`, `title` 추가
- 파일 Select를 헤더에서 바디 상단으로 이동
- 파일 모드 바디에 레포지토리 링크 추가

#### 2. 데모 데이터 레포지토리 표시
- `demoFlashcards.ts`: `metadata.repositoryFullName` 추가로 랜딩 데모에서 레포 표시

#### 3. 파일 보기 API 에러 UX 개선
- 기술적 에러 메시지 → 사용자 친화적 한글로 변환 (`formatFileErrorForUser`)
- Network Error → "인터넷 연결을 확인해주세요." 등으로 변경
- 에러 UI: 아이콘(WifiOff) + 안내 문구 + "다시 시도" 버튼

#### 4. 스크롤·스와이프 우선 처리 (모바일)
- 가로 스크롤 가능 시 스크롤을 먼저 처리하고, 스크롤 끝에서만 카드 전환
- `touch-action: pan-x pan-y` CSS 적용
- `useScrollPriorityTouch` 훅 추가 (Capture 터치 핸들러)

#### 추가/수정 파일
| 파일 | 내용 |
|------|------|
| `app/src/features/flashcard/FlashCardPlayer.tsx` | 탭 아이콘, Select 위치, 에러 UI, 스크롤 훅 적용 |
| `app/src/lib/formatError.ts` | `formatFileErrorForUser` 유틸 |
| `app/src/lib/useScrollPriorityTouch.ts` | 스크롤 우선 터치 핸들러 훅 |
| `app/src/lib/demoFlashcards.ts` | `repositoryFullName` 메타데이터 추가 |

### How to test

1. **탭 아이콘화**: 모바일 뷰(640px 이하)에서 카드 뒷면 탭이 아이콘만 한 줄로 표시되는지 확인
2. **파일 Select**: 파일 보기 선택 시 바디 상단에 파일 선택 드롭다운이 보이는지 확인
3. **레포 표시**: 데모 플래시카드와 로그인 플래시카드에서 레포 링크가 노출되는지 확인
4. **에러 UX**: 네트워크 끊김 등으로 파일 로드 실패 시, 안내 문구와 "다시 시도" 버튼이 보이는지 확인
5. **스크롤 우선**: 모바일(또는 DevTools 터치 시뮬레이션)에서 가로 스크롤 가능한 Diff/코드 영역을 스와이프할 때 스크롤이 먼저 되고, 끝에 도달한 뒤에만 카드가 넘어가는지 확인

### Review Requirement

- 모바일 터치 환경에서 스크롤·스와이프 동작이 의도대로 동작하는지 검증
- `formatFileErrorForUser`, `useScrollPriorityTouch` 훅이 다른 기능에서 재사용 가능한 형태로 분리되어 있는지 확인

### Additional Info

- **Diff UX 관련 Notion**: [Diff UX - 플래시카드 뒷면 탭·Select 개선](https://www.notion.so/chucoding/Diff-UX-314fd64d44a08044ba51c20b2f7708ac)
- **스와이프 관련 Notion**: [스와이프 - 스크롤 우선 처리](https://www.notion.so/chucoding/314fd64d44a080448c68cbc286a298bb)