### PR TITLE
[TSK-132] 플래시카드 헤더 레이아웃 및 GitHub 링크 UX 개선

### DIFF
--- a/.cursor/rules/github-icon.mdc
+++ b/.cursor/rules/github-icon.mdc
@@ -1,0 +1,20 @@
+---
+description: GitHub 아이콘은 프로젝트 SVG 사용, Lucide Github 아이콘 미사용
+alwaysApply: true
+---
+
+# GitHub 아이콘 규칙
+
+- **Lucide의 `Github` 아이콘은 사용하지 않는다.**
+- GitHub 로고/마크가 필요할 때는 프로젝트에 포함된 SVG를 사용한다:
+  - `public/github-mark.svg` - 밝은 배경용 (어두운 마크)
+  - `public/github-mark-white.svg` - 어두운 배경용
+
+```tsx
+// ❌ BAD - Lucide Github 아이콘
+import { Github } from 'lucide-react';
+<Github className="w-3.5 h-3.5" />
+
+// ✅ GOOD - 프로젝트 SVG
+<img src="/github-mark.svg" alt="" width={14} height={14} className="w-3.5 h-3.5 shrink-0" aria-hidden />
+```

--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -328,48 +328,56 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                   {isFlipped ? (
                     <div className="fc-card-back w-full h-full flex flex-col min-h-0">
                       <div
-                        className="fc-back-header flex flex-wrap items-center gap-1 p-2 border-b border-slate-200 bg-slate-50 shrink-0 rounded-t-3xl"
+                        className="fc-back-header flex items-center justify-between gap-2 p-2 border-b border-slate-200 bg-slate-50 shrink-0 rounded-t-3xl"
                         onClick={(e) => e.stopPropagation()}
-                        role="tablist"
-                        aria-label="뒷면 보기 모드"
                       >
-                        {card.metadata?.repositoryFullName && (
+                        {card.metadata?.repositoryFullName ? (
                           <a
                             href={`https://github.com/${card.metadata.repositoryFullName}`}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1.5 mr-2 px-2 py-1 rounded-lg bg-white border border-slate-200 text-[0.75rem] font-mono text-slate-600 no-underline transition-colors duration-200 hover:bg-slate-100 hover:border-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+                            className="min-w-0 flex-1 overflow-hidden inline-flex items-center gap-1.5 h-9 mr-2 px-2 rounded-lg bg-white border border-slate-200 text-[0.75rem] font-mono text-slate-600 no-underline transition-colors duration-200 hover:bg-slate-100 hover:border-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
                             onClick={(e) => e.stopPropagation()}
+                            aria-label={`GitHub에서 ${card.metadata.repositoryFullName} 레포지토리 열기`}
+                            title={`GitHub에서 레포지토리 열기 (${card.metadata.repositoryFullName})`}
                           >
-                            <Folder className="w-3.5 h-3.5 shrink-0" aria-hidden />
-                            <span className="truncate max-w-[140px] sm:max-w-[200px]" title={card.metadata.repositoryFullName}>{card.metadata.repositoryFullName}</span>
+                            <img src="/github-mark.svg" alt="" width={14} height={14} className="w-3.5 h-3.5 shrink-0" aria-hidden />
+                            <span className="min-w-0 truncate">{card.metadata.repositoryFullName}</span>
                           </a>
+                        ) : (
+                          <div className="min-w-0 flex-1" />
                         )}
-                        <button
-                          type="button"
-                          role="tab"
-                          aria-selected={backViewMode === 'diff'}
-                          aria-label="Diff 보기"
-                          title="Diff 보기"
-                          className={`fc-tab flex items-center justify-center gap-1.5 w-9 h-9 sm:min-w-[88px] sm:w-auto sm:py-2 sm:px-3 rounded-xl text-sm font-medium transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${backViewMode === 'diff' ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-slate-800 hover:bg-slate-100'}`}
-                          onClick={() => setBackViewMode('diff')}
+                        <div
+                          className="flex shrink-0 items-center gap-1"
+                          role="tablist"
+                          aria-label="뒷면 보기 모드"
                         >
-                          <GitCompare className="w-4 h-4 shrink-0" aria-hidden />
-                          <span className="hidden sm:inline">Diff 보기</span>
-                        </button>
-                        <button
-                          type="button"
-                          role="tab"
-                          aria-selected={backViewMode === 'file'}
-                          aria-label="파일 보기"
-                          title="파일 보기"
-                          disabled={!hasFileView}
-                          className={`fc-tab flex items-center justify-center gap-1.5 w-9 h-9 sm:min-w-[88px] sm:w-auto sm:py-2 sm:px-3 rounded-xl text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${backViewMode === 'file' ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-slate-800 hover:bg-slate-100'} ${hasFileView ? 'cursor-pointer' : ''}`}
-                          onClick={() => hasFileView && setBackViewMode('file')}
-                        >
-                          <FileText className="w-4 h-4 shrink-0" aria-hidden />
-                          <span className="hidden sm:inline">파일 보기</span>
-                        </button>
+                          <button
+                            type="button"
+                            role="tab"
+                            aria-selected={backViewMode === 'diff'}
+                            aria-label="Diff 보기"
+                            title="Diff 보기"
+                            className={`fc-tab flex items-center justify-center gap-1.5 w-9 h-9 sm:min-w-[88px] sm:w-auto sm:py-2 sm:px-3 rounded-xl text-sm font-medium transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${backViewMode === 'diff' ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-slate-800 hover:bg-slate-100'}`}
+                            onClick={() => setBackViewMode('diff')}
+                          >
+                            <GitCompare className="w-4 h-4 shrink-0" aria-hidden />
+                            <span className="hidden sm:inline">Diff 보기</span>
+                          </button>
+                          <button
+                            type="button"
+                            role="tab"
+                            aria-selected={backViewMode === 'file'}
+                            aria-label="파일 보기"
+                            title="파일 보기"
+                            disabled={!hasFileView}
+                            className={`fc-tab flex items-center justify-center gap-1.5 w-9 h-9 sm:min-w-[88px] sm:w-auto sm:py-2 sm:px-3 rounded-xl text-sm font-medium transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${backViewMode === 'file' ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-slate-800 hover:bg-slate-100'} ${hasFileView ? 'cursor-pointer' : ''}`}
+                            onClick={() => hasFileView && setBackViewMode('file')}
+                          >
+                            <FileText className="w-4 h-4 shrink-0" aria-hidden />
+                            <span className="hidden sm:inline">파일 보기</span>
+                          </button>
+                        </div>
                       </div>
                       <div
                         className="fc-highlight-guide flex items-center gap-1.5 px-3 py-1.5 border-b border-slate-100 bg-amber-50/60 text-slate-600 text-[11px] shrink-0"
@@ -391,9 +399,11 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="inline-flex items-center gap-1.5 text-[0.75rem] font-mono text-slate-600 no-underline transition-colors duration-200 hover:text-slate-800 hover:underline"
+                                aria-label={`GitHub에서 ${card.metadata.repositoryFullName} 레포지토리 열기`}
+                                title={`GitHub에서 레포지토리 열기 (${card.metadata.repositoryFullName})`}
                               >
-                                <Folder className="w-3.5 h-3.5 shrink-0" aria-hidden />
-                                <span className="truncate max-w-full" title={card.metadata.repositoryFullName}>{card.metadata.repositoryFullName}</span>
+                                <img src="/github-mark.svg" alt="" width={14} height={14} className="w-3.5 h-3.5 shrink-0" aria-hidden />
+                                <span className="truncate max-w-full">{card.metadata.repositoryFullName}</span>
                               </a>
                             )}
                             {hasFilesArray && effectiveFiles.length > 1 ? (


### PR DESCRIPTION
### Purpose

플래시카드 뒷면 헤더의 레이아웃을 정리하고, 레포지토리 링크가 GitHub로 이동한다는 점을 더 분명히 드러낸다.

### Description

**1. 헤더 레이아웃**
- Diff 보기 / 파일 보기 버튼을 **오른쪽 끝에 고정 정렬**
- 레포지토리명은 왼쪽에 **가용 너비만큼 표시**, 넘치면 **말줄임표** 처리
- 레포지토리 링크와 버튼 높이를 `h-9`로 통일

**2. GitHub 링크 인지성**
- Folder 아이콘 → `public/github-mark.svg` 사용
- `aria-label`, `title` 툴팁으로 "GitHub에서 레포지토리 열기"를 명시

**3. GitHub 아이콘 규칙**
- Lucide `Github` 아이콘 사용 금지
- `.cursor/rules/github-icon.mdc` 추가

| 파일 | 변경 내용 |
|------|-----------|
| `app/src/features/flashcard/FlashCardPlayer.tsx` | 헤더 레이아웃, SVG 아이콘, 접근성 속성 |
| `.cursor/rules/github-icon.mdc` | GitHub 아이콘 사용 규칙 |

### How to test

1. 앱 실행 후 플래시카드를 하나 선택해 뒷면을 연다.
2. 헤더에서 다음을 확인한다:
   - 레포지토리명이 왼쪽, Diff/파일 보기 버튼이 오른쪽 끝에 있는지
   - 레포지토리명이 길 때 말줄임표로 잘리는지
   - 레포 링크와 버튼 높이가 같은지
3. 레포지토리 링크에 마우스를 올렸을 때 "GitHub에서 레포지토리 열기" 툴팁이 보이는지 확인한다.
4. 레포지토리 링크를 클릭해 GitHub로 정상 이동하는지 확인한다.

### Review Requirement

- `flex justify-between`과 `min-w-0 truncate`로 레이아웃이 의도대로 동작하는지
- 모바일 등 좁은 화면에서 레포지토리명 말줄임표가 정상 동작하는지
- `aria-label`, `title`이 접근성에 적절한지

### Additional Info

- **관련 Notion**: [플레시카드 헤더 UX](https://www.notion.so/chucoding/UX-314fd64d44a08044ba51c20b2f7708ac)