### PR TITLE
[TSK-138] 플래시카드 삭제 기능 추가 및 키보드 인디케이터 모듈화

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",
     "slick-carousel": "^1.8.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.1.18",
     "zustand": "^5.0.8"

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { Toaster } from 'sonner';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
 
@@ -181,6 +182,7 @@ const App: React.FC = () => {
   // 메인 앱 렌더링
   return (
     <>
+      <Toaster position="bottom-center" richColors closeButton />
       <main>
         {/* 플로팅 navbar: transparent 영역은 pointer-events-none으로 아래 콘텐츠 클릭 통과, 버튼만 pointer-events-auto (ui-ux-pro-max: Content padding, Floating navbar) */}
         <nav className={`fixed top-4 left-4 right-4 max-[768px]:top-2 max-[768px]:left-2 max-[768px]:right-2 bg-transparent z-[1000] px-5 py-3 max-[768px]:py-2 max-[768px]:px-3 flex justify-between items-center transition-all duration-300 ease-in-out pointer-events-none ${isScrollAtTop ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-5'}`}>

--- a/app/src/components/FlashCardKeyboardIndicator.tsx
+++ b/app/src/components/FlashCardKeyboardIndicator.tsx
@@ -1,0 +1,41 @@
+const kbdClass =
+  'bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]';
+
+export interface FlashCardKeyboardIndicatorProps {
+  /** 삭제 단축키( Del ) 표시 여부. 기본 true */
+  showDelete?: boolean;
+  /** 컨테이너 추가 className */
+  className?: string;
+}
+
+/**
+ * 플래시카드 키보드 단축키 안내 (데스크톱 전용, 768px 이하에서 숨김)
+ */
+export function FlashCardKeyboardIndicator({
+  showDelete = true,
+  className = '',
+}: FlashCardKeyboardIndicatorProps) {
+  return (
+    <div
+      className={`inline-flex bg-surface/90 px-5 py-2.5 rounded-[20px] shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] text-text-light backdrop-blur-sm gap-4 items-center border border-border animate-fade-in max-[768px]:hidden ${className}`}
+      role="status"
+      aria-label="키보드 단축키 안내"
+    >
+      <div className="flex items-center gap-1.5">
+        <kbd className={kbdClass}>&larr;</kbd>
+        <kbd className={kbdClass}>&rarr;</kbd>
+        <span>이동</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <kbd className={kbdClass}>Space</kbd>
+        <span>뒤집기</span>
+      </div>
+      {showDelete && (
+        <div className="flex items-center gap-1.5">
+          <kbd className={kbdClass}>Del</kbd>
+          <span>삭제</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/features/flashcard/index.ts
+++ b/app/src/features/flashcard/index.ts
@@ -1,3 +1,3 @@
 export { default as FlashCardPlayer } from './FlashCardPlayer';
-export type { FlashCardPlayerProps } from './FlashCardPlayer';
+export type { FlashCardPlayerProps, DeleteMethod } from './FlashCardPlayer';
 export type { FlashCard } from './types';

--- a/app/src/landing-main.tsx
+++ b/app/src/landing-main.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
+import { Toaster } from 'sonner';
 import Clarity from '@microsoft/clarity';
 import './index.css';
 import LandingDemo from './pages/LandingDemo';
@@ -16,6 +17,7 @@ const demoRoot = document.getElementById('demo-root');
 if (demoRoot) {
   ReactDOM.createRoot(demoRoot).render(
     <React.StrictMode>
+      <Toaster position="bottom-center" richColors closeButton />
       <LandingDemo />
     </React.StrictMode>
   );

--- a/app/src/lib/useSwipeUpToDelete.ts
+++ b/app/src/lib/useSwipeUpToDelete.ts
@@ -1,0 +1,44 @@
+import { useCallback, useRef } from 'react';
+
+const SWIPE_UP_THRESHOLD_PX = 80;
+const SWIPE_MAX_DURATION_MS = 400;
+
+/**
+ * 위로 스와이프 제스처를 감지하여 삭제 콜백 호출.
+ * 모바일(768px 이하)에서만 활성화. 스크롤 영역에서는 사용하지 않음.
+ */
+export function useSwipeUpToDelete(
+  onSwipeUp: () => void,
+  enabled: boolean
+) {
+  const touchStartRef = useRef<{ y: number; t: number } | null>(null);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (!enabled) return;
+      touchStartRef.current = {
+        y: e.touches[0].clientY,
+        t: Date.now(),
+      };
+    },
+    [enabled]
+  );
+
+  const onTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (!enabled || !touchStartRef.current) return;
+      const start = touchStartRef.current;
+      const endY = e.changedTouches[0].clientY;
+      const deltaY = start.y - endY;
+      const duration = Date.now() - start.t;
+      touchStartRef.current = null;
+
+      if (deltaY >= SWIPE_UP_THRESHOLD_PX && duration <= SWIPE_MAX_DURATION_MS) {
+        onSwipeUp();
+      }
+    },
+    [enabled, onSwipeUp]
+  );
+
+  return { onTouchStart, onTouchEnd };
+}

--- a/app/src/pages/FlashCardViewer.tsx
+++ b/app/src/pages/FlashCardViewer.tsx
@@ -25,6 +25,7 @@ import { useNavigationStore } from '../stores/navigationStore';
 import { getCurrentDate, shuffleArray } from '../modules/utils';
 import { Shuffle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { FlashCardKeyboardIndicator } from '@/components/FlashCardKeyboardIndicator';
 
 /**
  * 로그인 사용자 전용 플래시카드 뷰어
@@ -114,17 +115,7 @@ const FlashCardViewer: React.FC = () => {
       <div className="flex flex-col max-[768px]:flex-shrink-0 max-[768px]:w-full">
         {/* 데스크톱: 키보드 안내 + 셔플 | 모바일: 인디케이터 + 셔플 한 줄 (설정 버튼은 App nav에 있음) */}
         <div className="flex flex-wrap justify-center gap-3 mb-2 relative z-[100] max-[768px]:gap-2 max-[768px]:justify-between max-[768px]:items-center max-[768px]:mb-3 shrink-0">
-          <div className="inline-flex bg-surface/90 px-5 py-2.5 rounded-[20px] shadow-[0_4px_12px_rgba(0,0,0,0.3)] text-[0.85rem] text-text-light backdrop-blur-sm gap-4 items-center border border-border animate-fade-in max-[768px]:hidden">
-            <div className="flex items-center gap-1.5">
-              <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">&larr;</kbd>
-              <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">&rarr;</kbd>
-              <span>이동</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <kbd className="bg-surface-light border border-border-medium rounded px-2 py-0.5 font-mono text-[0.75rem] text-text shadow-[0_1px_2px_rgba(0,0,0,0.2)]">Space</kbd>
-              <span>뒤집기</span>
-            </div>
-          </div>
+          <FlashCardKeyboardIndicator showDelete />
           {/* 모바일만: 인디케이터 + 셔플 한 줄 (동일 pill 스타일로 조화). 데스크톱에서는 hidden만 적용되도록 inline-flex는 768 이하에서만 */}
           <span className={`hidden max-[768px]:inline-flex max-[768px]:order-first ${indicatorPillClass}`} aria-live="polite">
             {currentSlide + 1} / {cards.length}

--- a/app/src/pages/PastDateReview.tsx
+++ b/app/src/pages/PastDateReview.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
-import { doc, getDoc } from 'firebase/firestore';
+import React, { useCallback, useEffect, useState } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { toast } from 'sonner';
 import { FlashCardPlayer } from '../features/flashcard';
-import type { FlashCard } from '../features/flashcard';
+import type { FlashCard, DeleteMethod } from '../features/flashcard';
 import { auth, store } from '../firebase';
+import { trackEvent } from '../analytics';
 import { useNavigationStore } from '../stores/navigationStore';
 import { Button } from '@/components/ui/button';
 
@@ -13,6 +15,8 @@ interface PastDateReviewProps {
 const PastDateReview: React.FC<PastDateReviewProps> = ({ date }) => {
   const [cards, setCards] = useState<FlashCard[]>([]);
   const [loading, setLoading] = useState(true);
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const [syncSlideIndex, setSyncSlideIndex] = useState<number | null>(null);
   const setSelectedPastDate = useNavigationStore((s) => s.setSelectedPastDate);
 
   useEffect(() => {
@@ -35,6 +39,44 @@ const PastDateReview: React.FC<PastDateReviewProps> = ({ date }) => {
       </div>
     );
   }
+
+  const handleDeleteCard = useCallback((index: number, method: DeleteMethod) => {
+    const deletedCard = cards[index];
+    const newCards = cards.filter((_, i) => i !== index);
+    const newSlide = index >= newCards.length ? Math.max(0, newCards.length - 1) : index;
+
+    setCards(newCards);
+    setCurrentSlide(newSlide);
+    setSyncSlideIndex(newSlide);
+
+    const user = auth.currentUser;
+    if (user) {
+      const flashcardDocRef = doc(store, 'users', user.uid, 'flashcards', date);
+      setDoc(flashcardDocRef, { data: newCards });
+
+      toast('카드가 제거되었습니다', {
+        action: {
+          label: '실행 취소',
+          onClick: () => {
+            const restored = [...newCards];
+            restored.splice(index, 0, deletedCard);
+            setCards(restored);
+            setCurrentSlide(index);
+            setSyncSlideIndex(index);
+            setDoc(flashcardDocRef, { data: restored });
+          },
+        },
+        duration: 5000,
+      });
+    }
+
+    trackEvent('flashcard_delete', {
+      method,
+      card_index: index + 1,
+      total_before: cards.length,
+      total_after: newCards.length,
+    });
+  }, [cards, date]);
 
   if (cards.length === 0) {
     return (
@@ -62,7 +104,13 @@ const PastDateReview: React.FC<PastDateReviewProps> = ({ date }) => {
           오늘로 돌아가기
         </Button>
       </div>
-      <FlashCardPlayer cards={cards} keyboardShortcuts />
+      <FlashCardPlayer
+        cards={cards}
+        keyboardShortcuts
+        onSlideChange={(n) => { setCurrentSlide(n); setSyncSlideIndex(null); }}
+        onDeleteCard={handleDeleteCard}
+        slideIndex={syncSlideIndex ?? undefined}
+      />
     </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       slick-carousel:
         specifier: ^1.8.1
         version: 1.8.1(jquery@3.7.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -5312,6 +5315,12 @@ packages:
 
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -12358,6 +12367,11 @@ snapshots:
       jquery: 3.7.1
 
   smob@1.5.0: {}
+
+  sonner@2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
### Purpose

플래시카드 덱에서 불필요한 카드를 제거할 수 있는 삭제 기능을 추가하고, 키보드 단축키 안내를 모듈화하여 FlashCardViewer와 LandingDemo에서 재사용할 수 있게 합니다.

### Description

#### 플래시카드 삭제 기능

| 구분 | 내용 |
|------|------|
| 삭제 방식 | 삭제 버튼(앞/뒷면), 위로 스와이프(모바일), Delete/Backspace 키 |
| 실행 취소 | 삭제 후 5초간 토스트에 "실행 취소" 버튼 |
| 적용 범위 | FlashCardViewer, PastDateReview (Firestore 반영), LandingDemo (로컬 state만) |
| GA 이벤트 | `flashcard_delete` (method, card_index, total_before, total_after) |

#### 변경/추가 파일

| 파일 | 변경 내용 |
|------|-----------|
| `app/package.json` | sonner 의존성 추가 |
| `app/src/App.tsx` | Toaster 렌더링 |
| `app/src/landing-main.tsx` | Toaster 렌더링 (데모 토스트용) |
| `app/src/lib/useSwipeUpToDelete.ts` | **신규** – 위로 스와이프 감지 훅 |
| `app/src/components/FlashCardKeyboardIndicator.tsx` | **신규** – 키보드 단축키 안내 컴포넌트 (모듈화) |
| `app/src/features/flashcard/FlashCardPlayer.tsx` | onDeleteCard, slideIndex, 삭제 버튼, 스와이프·키보드 핸들러, 슬라이드 동기화 |
| `app/src/features/flashcard/index.ts` | DeleteMethod 타입 export |
| `app/src/pages/FlashCardViewer.tsx` | handleDeleteCard, toast, Firestore 반영, FlashCardKeyboardIndicator 사용 |
| `app/src/pages/PastDateReview.tsx` | handleDeleteCard, onSlideChange, slideIndex 전달 |
| `app/src/pages/LandingDemo.tsx` | 삭제 기능 추가, 키보드 인디케이터, Toaster 연동 |

#### UI/UX

- 삭제 버튼: Lucide Trash2, 오른쪽 상단, 최소 44x44px 터치 영역
- 키보드 인디케이터: 이동(←→), 뒤집기(Space), 삭제(Del) – 데스크톱 전용 (768px 이하 숨김)

### How to test

1. **FlashCardViewer (앱)**
   - 로그인 후 플래시카드 진입
   - 삭제 버튼 클릭 → 카드 제거, 토스트 표시, "실행 취소" 클릭 시 복구
   - Delete/Backspace 키 → 동일 동작
   - 모바일(768px 이하): 카드 위로 스와이프 → 삭제
   - 키보드 인디케이터(이동, 뒤집기, 삭제) 노출 확인

2. **PastDateReview**
   - 과거 날짜 복습 진입 후 위와 동일하게 삭제/실행 취소 확인

3. **LandingDemo**
   - 랜딩 페이지에서 레포 URL로 카드 생성
   - 삭제 버튼, 스와이프, Delete/Backspace 동작 확인
   - 토스트 + 실행 취소 동작 확인
   - 키보드 인디케이터 노출 확인

4. **마지막 카드 삭제**
   - 마지막 카드 삭제 시 빈 화면으로 전환되는지 확인

### Review Requirement

- `handleDeleteCard`에서 Firestore `setDoc`과 toast `onClick` 클로저가 올바르게 동작하는지
- `useSwipeUpToDelete` 임계값(80px, 400ms)과 스크롤 영역 충돌 여부
- `slideIndex` 동기화 로직과 `onSlideChange`에서 `syncSlideIndex` 클리어 타이밍

### Additional Info

- **관련 Notion**: [❌ 카드 삭제 버튼](https://www.notion.so/316fd64d44a0807a9515de531b85b53b)