### PR TITLE
[TSK-132] 플래시카드 앞·뒷면 헤더 재구성 및 브랜치 표기

### DIFF
--- a/app/src/features/flashcard/FlashCardPlayer.tsx
+++ b/app/src/features/flashcard/FlashCardPlayer.tsx
@@ -9,7 +9,7 @@ import { useScrollPriorityTouch } from '../../lib/useScrollPriorityTouch';
 import { useSwipeUpToDelete } from '../../lib/useSwipeUpToDelete';
 import type { FlashCard } from './types';
 import { trackEvent } from '../../analytics';
-import { Sparkles, Folder, GitCompare, FileText, WifiOff, RefreshCw, Trash2 } from 'lucide-react';
+import { Sparkles, GitBranch, GitCompare, FileText, WifiOff, RefreshCw, Trash2 } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -383,7 +383,7 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                   tabIndex={0}
                   aria-label={isFlipped ? t('flashcard.viewFront') : t('flashcard.viewBack')}
                   aria-busy={regeneratingIndex === i}
-                  className={`fc-card flex !flex items-center justify-center text-2xl text-center min-h-[50vh] max-h-[80vh] m-3 bg-white border-none rounded-3xl overflow-auto transition-all duration-300 p-10 shadow-[0_20px_60px_rgba(0,0,0,0.4),0_0_0_1px_rgba(34,197,94,0.25)] relative antialiased cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 max-[768px]:min-h-[40vh] max-[768px]:max-h-[75vh] max-[768px]:m-2 max-[768px]:p-6 max-[768px]:text-xl max-[768px]:rounded-[20px] max-[480px]:min-h-[35vh] max-[480px]:max-h-[70vh] max-[480px]:m-[5px] max-[480px]:p-4 max-[480px]:text-base max-[480px]:rounded-4 ${isFlipped ? 'flipped items-start justify-start text-left shadow-[0_25px_70px_rgba(0,0,0,0.5),0_0_0_1px_rgba(34,197,94,0.3)] p-0 overflow-hidden animate-[fc-flip-in_0.3s_ease-out]' : ''}`}
+                  className={`fc-card flex !flex items-center justify-center text-2xl text-center min-h-[50vh] max-h-[80vh] m-3 bg-white border-none rounded-3xl overflow-auto transition-all duration-300 shadow-[0_20px_60px_rgba(0,0,0,0.4),0_0_0_1px_rgba(34,197,94,0.25)] relative antialiased cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 max-[768px]:min-h-[40vh] max-[768px]:max-h-[75vh] max-[768px]:m-2 max-[768px]:text-xl max-[768px]:rounded-[20px] max-[480px]:min-h-[35vh] max-[480px]:max-h-[70vh] max-[480px]:m-[5px] max-[480px]:text-base max-[480px]:rounded-4 ${isFlipped ? 'flipped items-start justify-start text-left shadow-[0_25px_70px_rgba(0,0,0,0.5),0_0_0_1px_rgba(34,197,94,0.3)] overflow-hidden animate-[fc-flip-in_0.3s_ease-out]' : ''}`}
                   onClick={() => {
                     if (regeneratingIndex === i) return;
                     flipCard();
@@ -426,22 +426,6 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                         className="fc-back-header flex items-center justify-between gap-2 p-2 border-b border-slate-200 bg-slate-50 rounded-t-3xl"
                         onClick={(e) => e.stopPropagation()}
                       >
-                        {card.metadata?.repositoryFullName ? (
-                          <a
-                            href={`https://github.com/${card.metadata.repositoryFullName}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="min-w-0 flex-1 overflow-hidden inline-flex items-center gap-1.5 h-9 mr-2 px-2 rounded-lg bg-white border border-slate-200 text-[0.75rem] font-mono text-slate-600 no-underline transition-colors duration-200 hover:bg-slate-100 hover:border-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
-                            onClick={(e) => e.stopPropagation()}
-                            aria-label={t('flashcard.openRepoOnGitHub', { repo: card.metadata.repositoryFullName })}
-                            title={t('flashcard.openRepoOnGitHub', { repo: card.metadata.repositoryFullName })}
-                          >
-                            <img src="/github-mark.svg" alt="" width={14} height={14} className="w-3.5 h-3.5 shrink-0" aria-hidden />
-                            <span className="min-w-0 truncate">{card.metadata.repositoryFullName}</span>
-                          </a>
-                        ) : (
-                          <div className="min-w-0 flex-1" />
-                        )}
                         <div
                           className="flex shrink-0 items-center gap-1"
                           role="tablist"
@@ -472,6 +456,8 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                             <FileText className="w-4 h-4 shrink-0" aria-hidden />
                             <span className="hidden sm:inline">{t('flashcard.viewFile')}</span>
                           </button>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
                           {onRegenerateQuestion && card.metadata?.rawDiff && (
                             <button
                               type="button"
@@ -600,30 +586,49 @@ const FlashCardPlayer: React.FC<FlashCardPlayerProps> = ({
                       <AIAnswerFloatingBlock answer={card.answer} />
                     </div>
                   ) : (
-                    <div className="flex flex-col items-center justify-center w-full p-4 text-center relative">
-                      {onDeleteCard && (
-                        <button
-                          type="button"
-                          onClick={(e) => { e.stopPropagation(); onDeleteCard(i, 'button'); }}
-                          aria-label={t('flashcard.removeCard')}
-                          title={t('flashcard.removeCard')}
-                          className="absolute top-3 right-3 flex items-center justify-center min-w-[44px] min-h-[44px] w-9 h-9 rounded-xl text-slate-500 hover:bg-slate-100 hover:text-rose-600 transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 z-10"
-                        >
-                          <Trash2 className="w-4 h-4 shrink-0" aria-hidden />
-                        </button>
-                      )}
-                      {card.metadata?.repositoryFullName && (
-                        <span className="inline-flex items-center gap-1.5 mb-2 px-2.5 py-1 rounded-lg bg-slate-100 border border-slate-200 text-[0.75rem] font-mono text-slate-600">
-                          <Folder className="w-3.5 h-3.5 shrink-0" aria-hidden />
-                          <span className="truncate max-w-[200px] sm:max-w-[280px]" title={card.metadata.repositoryFullName}>{card.metadata.repositoryFullName}</span>
+                    <div className="w-full h-full flex flex-col min-h-0">
+                      <div
+                        className="fc-front-header flex items-center justify-between gap-2 p-2 border-b border-slate-200 bg-slate-50 rounded-t-3xl"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <div className="min-w-0 flex items-center gap-1.5 overflow-hidden">
+                          {card.metadata?.repositoryFullName && (
+                            <span className="inline-flex min-w-0 items-center gap-1.5 h-9 px-2 rounded-lg bg-white border border-slate-200 text-[0.75rem] font-mono text-slate-600">
+                              <img src="/github-mark.svg" alt="" width={14} height={14} className="w-3.5 h-3.5 shrink-0" aria-hidden />
+                              <span className="truncate max-w-[180px] sm:max-w-[260px]" title={card.metadata.repositoryFullName}>
+                                {card.metadata.repositoryFullName}
+                              </span>
+                            </span>
+                          )}
+                          {card.metadata?.branch && (
+                            <span className="inline-flex min-w-0 items-center gap-1.5 h-9 px-2 rounded-lg bg-white border border-slate-200 text-[0.75rem] font-mono text-slate-600">
+                              <GitBranch className="w-3.5 h-3.5 shrink-0" aria-hidden />
+                              <span className="truncate max-w-[110px] sm:max-w-[180px]" title={card.metadata.branch}>
+                                {card.metadata.branch}
+                              </span>
+                            </span>
+                          )}
+                        </div>
+                        {onDeleteCard && (
+                          <button
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); onDeleteCard(i, 'button'); }}
+                            aria-label={t('flashcard.removeCard')}
+                            title={t('flashcard.removeCard')}
+                            className="flex shrink-0 items-center justify-center min-w-[44px] min-h-[44px] w-9 h-9 rounded-xl text-slate-500 hover:bg-slate-100 hover:text-rose-600 transition-colors duration-200 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+                          >
+                            <Trash2 className="w-4 h-4 shrink-0" aria-hidden />
+                          </button>
+                        )}
+                      </div>
+                      <div className="flex-1 min-h-0 flex flex-col items-center justify-center w-full p-4 sm:p-8 text-center">
+                        <span className="inline-block mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                          {t('flashcard.question')}
                         </span>
-                      )}
-                      <span className="inline-block mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                        {t('flashcard.question')}
-                      </span>
-                      <p className="text-[1.6rem] font-semibold text-[#1D232B] leading-[1.7] break-words [word-break:keep-all] whitespace-pre-line max-[768px]:text-[1.3rem] max-[480px]:text-[1.15rem]">
-                        {card.question}
-                      </p>
+                        <p className="text-[1.6rem] font-semibold text-[#1D232B] leading-[1.7] break-words [word-break:keep-all] whitespace-pre-line max-[768px]:text-[1.3rem] max-[480px]:text-[1.15rem]">
+                          {card.question}
+                        </p>
+                      </div>
                     </div>
                   )}
                 </div>

--- a/app/src/features/flashcard/types.ts
+++ b/app/src/features/flashcard/types.ts
@@ -14,5 +14,7 @@ export interface FlashCard {
     filename?: string;
     /** 카드 출처 레포 (owner/repo). 다중 레포 시 표시용 */
     repositoryFullName?: string;
+    /** 카드 출처 브랜치 (없으면 default branch) */
+    branch?: string;
   };
 }

--- a/app/src/hooks/useTodayFlashcards.ts
+++ b/app/src/hooks/useTodayFlashcards.ts
@@ -183,7 +183,12 @@ async function generateFlashcards(
             question,
             answer,
             highlights: highlights?.filter((h): h is string => typeof h === "string" && h.length > 0),
-            metadata: { ...metadata, rawDiff: content, repositoryFullName: repoFullName, branch: resolvedBranch }
+            metadata: {
+              ...metadata,
+              rawDiff: content,
+              repositoryFullName: repoFullName,
+              ...(resolvedBranch ? { branch: resolvedBranch } : {}),
+            }
           });
         }
       } catch (error) {

--- a/app/src/hooks/useTodayFlashcards.ts
+++ b/app/src/hooks/useTodayFlashcards.ts
@@ -7,7 +7,7 @@ import { chatCompletions } from '../api/ai-api';
 import { translateFlashcards as translateFlashcardsApi } from '../api/translate-api';
 import type { FlashcardStructuredOutput } from '../types';
 import type { SubscriptionTier } from '../types';
-import { getCommits, getFilename, type CommitDetail, type FileChange } from '../api/github-api';
+import { getCommits, getFilename, getRepositories, type CommitDetail, type FileChange } from '../api/github-api';
 import { getCurrentDate } from '../modules/utils';
 import { useNavigationStore } from '../stores/navigationStore';
 import { useSubscription } from './useSubscription';
@@ -24,6 +24,7 @@ export interface FlashCardData {
     rawDiff?: string;
     files?: FileChange[];
     repositoryFullName?: string;
+    branch?: string;
   };
 }
 
@@ -86,6 +87,10 @@ export function useTodayFlashcards(user: User | null) {
 
         const currentDeck = getDeckByLang(docData, currentLang);
         if (currentDeck && currentDeck.length > 0) {
+          const branchEnriched = await enrichDeckWithResolvedBranches(currentDeck, repositories);
+          if (branchEnriched.changed) {
+            await setDoc(flashcardDocRef, { [`data_${currentLang}`]: branchEnriched.deck }, { merge: true });
+          }
           setLastLoadedDateKey(todayDate);
           setLoading(false);
           setHasData(true);
@@ -143,13 +148,15 @@ async function generateFlashcards(
   lang?: 'ko' | 'en'
 ): Promise<FlashCardData[]> {
   const list: FlashCardData[] = [];
+  const resolvedBranchByRepo = await resolveBranchByRepo(repositories);
 
   for (const repo of repositories) {
     const repoFullName = repo.fullName;
+    const resolvedBranch = resolvedBranchByRepo[repoFullName];
 
     for (const d of datesAgo) {
       try {
-        const githubData = await getGithubData(d, repoFullName, repo.branch);
+        const githubData = await getGithubData(d, repoFullName, resolvedBranch);
 
         if (!githubData) {
           continue;
@@ -170,7 +177,7 @@ async function generateFlashcards(
             question,
             answer,
             highlights: highlights?.filter((h): h is string => typeof h === "string" && h.length > 0),
-            metadata: { ...metadata, rawDiff: content, repositoryFullName: repoFullName }
+            metadata: { ...metadata, rawDiff: content, repositoryFullName: repoFullName, branch: resolvedBranch }
           });
         }
       } catch (error) {
@@ -180,6 +187,66 @@ async function generateFlashcards(
   }
 
   return list;
+}
+
+async function resolveBranchByRepo(
+  repositories: Array<{ fullName: string; url: string; branch?: string }>
+): Promise<Record<string, string | undefined>> {
+  const explicit = new Map<string, string | undefined>();
+  for (const repo of repositories) {
+    explicit.set(repo.fullName, repo.branch);
+  }
+
+  const unresolved = repositories.filter((repo) => !repo.branch).map((repo) => repo.fullName);
+  if (unresolved.length === 0) {
+    return Object.fromEntries(explicit);
+  }
+
+  try {
+    const accessibleRepos = await getRepositories();
+    const defaultMap = new Map(
+      accessibleRepos
+        .filter((r) => typeof r.default_branch === 'string' && r.default_branch.length > 0)
+        .map((r) => [r.full_name, r.default_branch as string])
+    );
+    for (const fullName of unresolved) {
+      if (!explicit.get(fullName)) {
+        explicit.set(fullName, defaultMap.get(fullName));
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to resolve default branches:', error);
+  }
+
+  return Object.fromEntries(explicit);
+}
+
+async function enrichDeckWithResolvedBranches(
+  deck: FlashCardData[],
+  repositories: Array<{ fullName: string; url: string; branch?: string }>
+): Promise<{ deck: FlashCardData[]; changed: boolean }> {
+  const needsEnrichment = deck.some((card) => card.metadata?.repositoryFullName && !card.metadata?.branch);
+  if (!needsEnrichment) return { deck, changed: false };
+
+  const resolvedBranchByRepo = await resolveBranchByRepo(repositories);
+  let changed = false;
+
+  const enriched = deck.map((card) => {
+    const repoName = card.metadata?.repositoryFullName;
+    if (!repoName || card.metadata?.branch) return card;
+    const resolvedBranch = resolvedBranchByRepo[repoName];
+    if (!resolvedBranch) return card;
+    changed = true;
+    return {
+      ...card,
+      metadata: {
+        ...card.metadata,
+        branch: resolvedBranch,
+      },
+    };
+  });
+
+  return { deck: enriched, changed };
 }
 
 interface GithubData {

--- a/app/src/hooks/useTodayFlashcards.ts
+++ b/app/src/hooks/useTodayFlashcards.ts
@@ -87,13 +87,19 @@ export function useTodayFlashcards(user: User | null) {
 
         const currentDeck = getDeckByLang(docData, currentLang);
         if (currentDeck && currentDeck.length > 0) {
-          const branchEnriched = await enrichDeckWithResolvedBranches(currentDeck, repositories);
-          if (branchEnriched.changed) {
-            await setDoc(flashcardDocRef, { [`data_${currentLang}`]: branchEnriched.deck }, { merge: true });
-          }
           setLastLoadedDateKey(todayDate);
           setLoading(false);
           setHasData(true);
+          // Best-effort: persist branch enrichment so next load gets it. Do not block read path (Firestore write failure must not hide cached deck).
+          enrichDeckWithResolvedBranches(currentDeck, repositories)
+            .then((branchEnriched) => {
+              if (branchEnriched.changed) {
+                return setDoc(flashcardDocRef, { [`data_${currentLang}`]: branchEnriched.deck }, { merge: true });
+              }
+            })
+            .catch((err) => {
+              console.warn('Flashcard branch enrichment (best-effort) failed:', err);
+            });
           return;
         }
 

--- a/app/src/lib/demoFlashcards.ts
+++ b/app/src/lib/demoFlashcards.ts
@@ -140,6 +140,21 @@ function toFileChangeList(
   }));
 }
 
+async function getDefaultBranch(owner: string, repo: string): Promise<string | undefined> {
+  try {
+    const repoRes = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+    });
+    if (!repoRes.ok) return undefined;
+    const repoData = (await repoRes.json()) as { default_branch?: string };
+    return typeof repoData.default_branch === 'string' && repoData.default_branch.length > 0
+      ? repoData.default_branch
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export type GenerateDemoFlashcardsResult =
   | { ok: true; cards: FlashCard[] }
   | { ok: false; error: string };
@@ -157,7 +172,8 @@ export async function generateDemoFlashcards(repoUrl: string, lang?: 'ko' | 'en'
     return { ok: false, error: i18n.t('demo.invalidRepoUrl', { lng }) };
   }
 
-  const shaParam = parsed.branch ? `&sha=${encodeURIComponent(parsed.branch)}` : '';
+  const resolvedBranch = parsed.branch || await getDefaultBranch(parsed.owner, parsed.repo);
+  const shaParam = resolvedBranch ? `&sha=${encodeURIComponent(resolvedBranch)}` : '';
   const commitsRes = await fetch(
     `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/commits?per_page=3${shaParam}`,
     { headers: { Accept: 'application/vnd.github.v3+json' } }
@@ -216,6 +232,7 @@ export async function generateDemoFlashcards(repoUrl: string, lang?: 'ko' | 'en'
       metadata: {
         commitMessage: commit.commit.message.split('\n')[0],
         repositoryFullName,
+        branch: resolvedBranch,
         ...(rawDiff && { rawDiff }),
         ...(files.length > 0 && { files }),
       },

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -16,6 +16,7 @@ export interface Repository {
   id: number;
   name: string;
   full_name: string;
+  default_branch?: string;
   description: string | null;
   html_url: string;
   private: boolean;


### PR DESCRIPTION
### Purpose

플래시카드 앞면에 레포·브랜치·삭제를 한 줄 헤더로 두고, 뒷면은 Diff/파일 보기·재생성·삭제만 두어 역할을 나눈다. 사용자가 브랜치를 지정하지 않아도 default 브랜치명(main/master 등)이 보이도록 표기 및 데이터 저장을 추가한다.

### Description

- **앞면 헤더**
  - 기존: 중앙 배지 + absolute 삭제 버튼 → **변경**: 뒷면과 같은 헤더 바(`fc-front-header`)
  - 좌측: 레포 배지(GitHub SVG `public/github-mark.svg`) + 브랜치 배지(Lucide `GitBranch` + 브랜치명)
  - 우측: 삭제 버튼
  - 브랜치 미지정 시에도 **실제 default 브랜치명**을 API로 조회해 표시

- **뒷면 헤더**
  - 레포 링크 제거(앞면에서 이미 표시)
  - 좌측: Diff 보기 / 파일 보기 탭
  - 우측: 재생성, 삭제 버튼

- **데이터**
  - `FlashCard.metadata`에 `branch?: string` 추가
  - 로그인: `useTodayFlashcards`에서 카드 생성 시 `repo.branch` 또는 `getRepositories()`로 해석한 default 브랜치 저장; 캐시 덱 로드 시 `branch` 비어 있으면 보정 후 저장
  - 데모: `demoFlashcards`에서 `parsed.branch` 또는 `GET /repos/{owner}/{repo}`로 조회한 default 브랜치 저장

- **수정/추가 파일**
  - `app/src/features/flashcard/types.ts` — `metadata.branch` 추가
  - `app/src/features/flashcard/FlashCardPlayer.tsx` — 앞면 헤더 바, 뒷면 헤더 단순화, 브랜치 배지(Folder → GitHub 아이콘 규칙 준수)
  - `app/src/hooks/useTodayFlashcards.ts` — `branch` 저장, `resolveBranchByRepo`, `enrichDeckWithResolvedBranches`
  - `app/src/lib/demoFlashcards.ts` — `branch` 저장, `getDefaultBranch()` 추가
  - `app/src/types.ts` — `Repository.default_branch` 추가

- **추가 API**
  - 로그인: 카드 생성/캐시 보정 시 `getRepositories()` 1회
  - 데모: URL에 브랜치 없을 때 `GET https://api.github.com/repos/{owner}/{repo}` 1회

### How to test

1. **앞면 헤더**: 플래시카드 앞면에서 상단 헤더 바에 레포 배지(GitHub 아이콘 + owner/repo), 브랜치 배지(GitBranch + 브랜치명), 삭제 버튼이 한 줄로 보이는지 확인.
2. **default 브랜치**: 설정에서 브랜치를 "기본 브랜치"로 둔 레포로 오늘 카드를 생성한 뒤, 앞면에 해당 레포의 실제 default 브랜치명(main 등)이 보이는지 확인.
3. **뒷면 헤더**: 카드 뒤집었을 때 상단에 레포 링크 없이, 좌측에 Diff 보기/파일 보기 탭, 우측에 재생성·삭제만 있는지 확인.
4. **데모**: 랜딩 데모에서 `owner/repo`만 입력해 플래시카드 생성 시 앞면에 default 브랜치명이 표시되는지 확인.

### Review Requirement

- 앞면/뒷면 헤더 클릭 시 카드가 뒤집히지 않도록 `stopPropagation` 처리 여부
- `getRepositories()` / 데모용 `GET /repos` 호출 시점과 실패 시 fallback(브랜치 빈 값 유지) 동작
- 모바일에서 레포·브랜치 배지 truncate 및 터치 타겟(44px) 유지 여부

### Additional Info

- **관련 Notion**: [🃏 플래시카드 헤더](https://www.notion.so/chucoding/314fd64d44a08044ba51c20b2f7708ac)